### PR TITLE
MathSpec link has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nyx
-[Nyx](https://en.wikipedia.org/wiki/Nyx) is a high fidelity, fast, reliable and **[validated](https://nyxspace.com/MathSpec/)** astrodynamical toolkit library written in Rust.
+[Nyx](https://en.wikipedia.org/wiki/Nyx) is a high fidelity, fast, reliable and **[validated]([https://nyxspace.com/MathSpec/](https://nyxspace.com/nyxspace/MathSpec/))** astrodynamical toolkit library written in Rust.
 
 The target audience is researchers and astrodynamics engineers. The rationale for using Rust is to allow for very fast computations, guaranteed thread safety,
 and portability to all platforms supported by [Rust](https://forge.rust-lang.org/platform-support.html).


### PR DESCRIPTION
The current link in the README throws a 404. This simply changes it to the right MathSpec link found on nyxspace.com.

Since this does not affect any test cases, code coverage or validation, I lazily ignored the form.