### PR TITLE
Hotfix for versioning issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyx-space"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 resolver = "2"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
@@ -19,14 +19,14 @@ maintenance = { status = "actively-developed" }
 gitlab = { repository = "nyx-space/nyx", branch = "master" }
 
 [dependencies]
-nalgebra = "0.31"
+nalgebra = "=0.32"
 log = "0.4"
 hifitime = "=3.3.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 csv = "1"
-hyperdual = "1.1.0"
+hyperdual = "=1.2.0"
 bytes = "1.0"
 prost = "0.11"
 prost-derive = "0.11"

--- a/src/cosmic/spacecraft.rs
+++ b/src/cosmic/spacecraft.rs
@@ -432,7 +432,7 @@ impl<X: SpacecraftExt> State for BaseSpacecraft<X> {
 
         // Extract the orbit information
         let orbit_state = sc_state.fixed_rows::<6>(0).into_owned();
-        let orbit_stm = sc_full_stm.fixed_slice::<6, 6>(0, 0).into_owned();
+        let orbit_stm = sc_full_stm.fixed_view::<6, 6>(0, 0).into_owned();
         // Rebuild the orbit vector
         let mut orbit_vec = OVector::<f64, Const<42>>::zeros();
         orbit_vec[0] = orbit_state[0];

--- a/tests/propagation/stm.rs
+++ b/tests/propagation/stm.rs
@@ -386,7 +386,7 @@ fn sc_and_orbit_stm_chk() {
     );
 
     let sc_stm = final_sc.stm().unwrap();
-    let sc_orbit_stm = sc_stm.fixed_slice::<6, 6>(0, 0);
+    let sc_orbit_stm = sc_stm.fixed_view::<6, 6>(0, 0);
     assert_eq!(
         sc_orbit_stm,
         final_orbit.stm().unwrap(),


### PR DESCRIPTION
Update Cargo.toml dependencies and switch to using `fixed_view` for STM extractions

### Effects

Bump to nalgebra 0.32 and hyperdual 1.2.0, both locked versions now.


In the future, the project will used [cargo vendor](https://doc.rust-lang.org/cargo/commands/cargo-vendor.html).