### PR TITLE
(doc) add synthax coloring to codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Refer to the [showcase](https://nyxspace.com/showcase/).
 
 The "[maturin](https://crates.io/crates/maturin)" python package is used to build the python bindings.
 
-```
+```sh
 pip install maturin
 ```
 
 Build the python bindings using the following command.
-```
+```sh
 maturin build --cargo-extra-args="--features python"
 ```
 
@@ -72,7 +72,7 @@ This creates a wheel file in `./target/wheels/` which can be installed using `pi
 
 For development mode, the following command may be used that automatically installs the python module
 
-```
+```sh
 maturin develop --cargo-extra-args="--features python"
 ```
 
@@ -80,7 +80,7 @@ maturin develop --cargo-extra-args="--features python"
 
 This minimal example runs the scenario defined in `data/simple-scenario.toml` using the Python bindings.
 
-```
+```py
 from nyx_space import md
 from nyx_space import io
 from nyx_space import cosmic


### PR DESCRIPTION
### Effects

I just added syntax highlighting in the main README file to make it easier to read.

### If this is a new feature or a bug fix ...
- [ ] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [x] No.
- [ ] Yes and:
  - I have coded up, or updated, an existing test case; and
  - I have provided a GMAT script which confirms the result(s); and
  - I have updated the `VALIDATION.md` file with the new error data between nyx and GMAT.
  - I will specify the version of GMAT used for the validation.
