### PR TITLE
Add online measurement rejection

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -137,6 +137,7 @@ jobs:
           cargo test --lib
           cargo test stop_cond_nrho_apo
           cargo test od_robust
+          cargo test od_resid_reject_
           grcov . --binary-path ./target/debug/ -t lcov -s . > lcov.txt
 
       - name: Upload coverage report

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nyx-space"
 build = "build.rs"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "A high-fidelity space mission toolkit, with orbit propagation, estimation and some systems engineering"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,10 @@ pyo3 = {version = "0.17.3", optional = true, features = ["extension-module"]}
 pyo3-log = {version = "0.8.1", optional = true}
 numpy = {version = "0.17", optional = true}
 indicatif = {version = "0.17", features = ["rayon"]}
-rstats = "1.2.49"
+rstats = "1.2.50"
 thiserror = "1.0"
-parquet = "38.0.0"
-arrow = "38.0.0"
+parquet = "39.0.0"
+arrow = "39.0.0"
 shadow-rs = "0.21.0"
 serde_yaml = "0.9.21"
 whoami = "1.3.0"

--- a/src/od/kalman.rs
+++ b/src/od/kalman.rs
@@ -389,15 +389,14 @@ where
         let ratio_mat = prefit.transpose() * &h_p_ht * &prefit;
         let ratio = ratio_mat[0];
 
-        if let Some(resid_ratio_threshold) = resid_ratio_check {
-            if ratio > resid_ratio_threshold {
-                warn!(
-                    "{} measurement rejected: residual ratio {} > {}",
-                    epoch, ratio, resid_ratio_threshold
-                );
+        if let Some(ratio_thresh) = resid_ratio_check {
+            if ratio > ratio_thresh {
+                warn!("{epoch} msr rejected: residual ratio {ratio} > {ratio_thresh}");
                 // Perform only a time update and return
                 let pred_est = self.time_update(nominal_state)?;
                 return Ok((pred_est, Residual::rejected(epoch, prefit, ratio)));
+            } else {
+                debug!("{epoch} msr accepted: residual ratio {ratio} < {ratio_thresh}");
             }
         }
 

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -108,12 +108,24 @@ where
 
     /// Computes the measurement update with a provided real observation and computed observation.
     ///
-    ///Returns an error if the STM or sensitivity matrices were not updated.
+    /// The nominal state is the state used for the computed observation.
+    /// The real observation is the observation that was actually measured.
+    /// The computed observation is the observation that was computed from the nominal state.
+    ///
+    /// Returns the updated estimate and the residual. The residual may be zero if the residual ratio check prevented the ingestion of this measurement.
+    ///
+    /// # Arguments
+    ///
+    /// * `nominal_state`: the nominal state at which the observation was computed.
+    /// * `real_obs`: the real observation that was measured.
+    /// * `computed_obs`: the computed observation from the nominal state.
+    /// * `resid_ratio_check`: the ratio below which the measurement is considered to be valid.
     fn measurement_update(
         &mut self,
         nominal_state: T,
         real_obs: &OVector<f64, M>,
         computed_obs: &OVector<f64, M>,
+        resid_ratio_check: Option<f64>,
     ) -> Result<(Self::Estimate, residual::Residual<M>), NyxError>;
 
     /// Returns whether the filter is an extended filter (e.g. EKF)

--- a/src/od/msr/mod.rs
+++ b/src/od/msr/mod.rs
@@ -21,6 +21,7 @@ mod range;
 mod range_doppler;
 mod rangerate;
 
+pub use arc::TrackingArc;
 pub use range::RangeMsr;
 pub use range_doppler::RangeDoppler;
 pub use rangerate::RangeRate;

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -34,13 +34,16 @@ use crate::State;
 mod conf;
 pub use conf::{IterationConf, SmoothingArc};
 mod trigger;
+use rstats::Stats;
 pub use trigger::{CkfTrigger, EkfTrigger, KfTrigger};
+mod rejectcrit;
 
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::ops::Add;
 
 use self::msr::arc::TrackingArc;
+pub use self::rejectcrit::RejectCriteria;
 
 /// An orbit determination process. Note that everything passed to this structure is moved.
 #[allow(clippy::upper_case_acronyms)]
@@ -85,6 +88,8 @@ pub struct ODProcess<
     /// Vector of residuals available after a pass
     pub residuals: Vec<Residual<Msr::MeasurementSize>>,
     pub ekf_trigger: T,
+    /// Residual rejection criteria allows preventing bad measurements from affecting the estimation.
+    pub resid_crit: RejectCriteria,
     pub cosm: Arc<Cosm>,
     init_state: D::StateType,
     _marker: PhantomData<A>,
@@ -126,7 +131,13 @@ where
         + Allocator<f64, <S as State>::Size, A>
         + Allocator<f64, A, <S as State>::Size>,
 {
-    pub fn ekf(prop: PropInstance<'a, D, E>, kf: K, trigger: T, cosm: Arc<Cosm>) -> Self {
+    pub fn ekf(
+        prop: PropInstance<'a, D, E>,
+        kf: K,
+        trigger: T,
+        resid_crit: RejectCriteria,
+        cosm: Arc<Cosm>,
+    ) -> Self {
         let init_state = prop.state;
         Self {
             prop,
@@ -134,6 +145,7 @@ where
             estimates: Vec::with_capacity(10_000),
             residuals: Vec::with_capacity(10_000),
             ekf_trigger: trigger,
+            resid_crit,
             cosm,
             init_state,
             _marker: PhantomData::<A>,
@@ -502,10 +514,42 @@ where
 
                                 self.kf.update_h_tilde(h_tilde);
 
+                                let resid_ratio_check = match self.resid_crit {
+                                    RejectCriteria::None => None,
+                                    RejectCriteria::ResidualRatio { count, value } => {
+                                        if self.residuals.len() < count {
+                                            None
+                                        } else {
+                                            Some(value)
+                                        }
+                                    }
+                                    RejectCriteria::ZScoreMultiplier { count, value } => {
+                                        // Calculate the z-score of the residuals so far.
+                                        if self.residuals.len() < count {
+                                            None
+                                        } else {
+                                            let ratios = self
+                                                .residuals
+                                                .iter()
+                                                .map(|resid| resid.ratio)
+                                                .collect::<Vec<f64>>();
+                                            let ameanstd = ratios.ameanstd().unwrap();
+                                            // Compute the multiplier for the z-score.
+                                            let mean = ameanstd.centre;
+                                            let stddev = ameanstd.dispersion;
+                                            // zscore = (x-mean)/stddev
+                                            // => zscore > T <=> x > mean + T*stddev
+                                            // ^^^ That's the check we'll do.
+                                            Some(mean + value * stddev)
+                                        }
+                                    }
+                                };
+
                                 match self.kf.measurement_update(
                                     nominal_state,
                                     &msr.observation(),
                                     &computed_meas.observation(),
+                                    resid_ratio_check,
                                 ) {
                                     Ok((estimate, residual)) => {
                                         debug!("msr update #{msr_cnt} @ {epoch}");
@@ -672,16 +716,22 @@ where
         + Allocator<f64, <S as State>::Size, A>
         + Allocator<f64, A, <S as State>::Size>,
 {
-    pub fn ckf(prop: PropInstance<'a, D, E>, kf: K, cosm: Arc<Cosm>) -> Self {
+    pub fn ckf(
+        prop: PropInstance<'a, D, E>,
+        kf: K,
+        resid_crit: RejectCriteria,
+        cosm: Arc<Cosm>,
+    ) -> Self {
         let init_state = prop.state;
         Self {
             prop,
             kf,
             estimates: Vec::with_capacity(10_000),
             residuals: Vec::with_capacity(10_000),
-            cosm,
+            resid_crit,
             ekf_trigger: CkfTrigger {},
             init_state,
+            cosm,
             _marker: PhantomData::<A>,
         }
     }

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -517,7 +517,8 @@ where
                                 let resid_ratio_check = match self.resid_crit {
                                     RejectCriteria::None => None,
                                     RejectCriteria::ResidualRatio { count, value } => {
-                                        if self.residuals.len() < count {
+                                        if self.residuals.is_empty() || self.residuals.len() < count
+                                        {
                                             None
                                         } else {
                                             Some(value)
@@ -525,7 +526,8 @@ where
                                     }
                                     RejectCriteria::ZScoreMultiplier { count, value } => {
                                         // Calculate the z-score of the residuals so far.
-                                        if self.residuals.len() < count {
+                                        if self.residuals.is_empty() || self.residuals.len() < count
+                                        {
                                             None
                                         } else {
                                             let ratios = self

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -535,7 +535,7 @@ where
                                     Ok((estimate, residual)) => {
                                         debug!("processed msr #{msr_cnt} @ {epoch}");
 
-                                        if !estimate.predicted() {
+                                        if !residual.rejected {
                                             msr_accepted_cnt += 1;
                                         }
 
@@ -577,7 +577,7 @@ where
                     if !reported[msr_prct] {
                         info!(
                             "{:>3}% done ({msr_accepted_cnt:.0} measurements accepted, {:.0} rejected)",
-                            10 * msr_prct, msr_cnt - msr_accepted_cnt
+                            10 * msr_prct, msr_cnt - (msr_accepted_cnt - 1)
                         );
                         reported[msr_prct] = true;
                     }

--- a/src/od/process/rejectcrit.rs
+++ b/src/od/process/rejectcrit.rs
@@ -1,0 +1,51 @@
+/*
+    Nyx, blazing fast astrodynamics
+    Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use crate::cosmic::Cosm;
+use crate::io::{ConfigError, ConfigRepr, Configurable};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Defines how to reject measurements based on the value of their residual ratios.
+/// The count is the minimum number of measurements to be ingested prior to applying the rejection criteria.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum RejectCriteria {
+    /// Reject measurements with a residual ratio greater than the provided value. This is a good default option when set to 3.0.
+    ResidualRatio { count: usize, value: f64 },
+    /// Reject measurements if their residual ratio is greater than the current z-score of the residual ratio multiplied by the provided value.
+    ZScoreMultiplier { count: usize, value: f64 },
+    /// Accept all measurements
+    None,
+}
+
+impl ConfigRepr for RejectCriteria {}
+
+impl Configurable for RejectCriteria {
+    type IntermediateRepr = Self;
+
+    fn from_config(cfg: Self, _cosm: Arc<Cosm>) -> Result<Self, ConfigError>
+    where
+        Self: Sized,
+    {
+        Ok(cfg)
+    }
+
+    fn to_config(&self) -> Result<Self::IntermediateRepr, ConfigError> {
+        Ok(*self)
+    }
+}

--- a/src/od/process/rejectcrit.rs
+++ b/src/od/process/rejectcrit.rs
@@ -18,24 +18,44 @@
 
 use crate::cosmic::Cosm;
 use crate::io::{ConfigError, ConfigRepr, Configurable};
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Defines how to reject measurements based on the value of their residual ratios.
-/// The count is the minimum number of measurements to be ingested prior to applying the rejection criteria.
+/// Reject measurements with a residual ratio greater than the provided value.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-pub enum RejectCriteria {
-    /// Reject measurements with a residual ratio greater than the provided value. This is a good default option when set to 3.0.
-    ResidualRatio { count: usize, value: f64 },
-    /// Reject measurements if their residual ratio is greater than the current z-score of the residual ratio multiplied by the provided value.
-    ZScoreMultiplier { count: usize, value: f64 },
-    /// Accept all measurements
-    None,
+#[cfg_attr(feature = "python", pyclass)]
+pub struct FltResid {
+    /// Minimum number of accepted measurements before applying the rejection criteria.
+    pub min_accepted: usize,
+    /// Number of sigmas for a measurement to be considered an outlier.
+    pub num_sigmas: f64,
 }
 
-impl ConfigRepr for RejectCriteria {}
+#[cfg(feature = "python")]
+impl FltResid {
+    fn __repr__(&self) -> String {
+        format!("{self:?}")
+    }
 
-impl Configurable for RejectCriteria {
+    fn __str__(&self) -> String {
+        format!("{self:?}")
+    }
+}
+
+impl Default for FltResid {
+    fn default() -> Self {
+        Self {
+            min_accepted: 10,
+            num_sigmas: 3.0,
+        }
+    }
+}
+
+impl ConfigRepr for FltResid {}
+
+impl Configurable for FltResid {
     type IntermediateRepr = Self;
 
     fn from_config(cfg: Self, _cosm: Arc<Cosm>) -> Result<Self, ConfigError>

--- a/src/od/process/rejectcrit.rs
+++ b/src/od/process/rejectcrit.rs
@@ -34,7 +34,30 @@ pub struct FltResid {
 }
 
 #[cfg(feature = "python")]
+#[pymethods]
 impl FltResid {
+    #[getter]
+    fn get_min_accepted(&self) -> usize {
+        self.min_accepted
+    }
+
+    #[setter(orbit)]
+    fn py_set_min_accepted(&mut self, min_accepted: usize) -> PyResult<()> {
+        self.min_accepted = min_accepted;
+        Ok(())
+    }
+
+    #[getter]
+    fn get_num_sigmas(&self) -> f64 {
+        self.num_sigmas
+    }
+
+    #[setter(orbit)]
+    fn py_set_num_sigmas(&mut self, num_sigmas: f64) -> PyResult<()> {
+        self.num_sigmas = num_sigmas;
+        Ok(())
+    }
+
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }

--- a/src/python/orbit_determination/mod.rs
+++ b/src/python/orbit_determination/mod.rs
@@ -23,6 +23,7 @@ use crate::io::tracking_data::DynamicTrackingArc;
 use crate::io::trajectory_data::DynamicTrajectory;
 use crate::od::msr::RangeDoppler;
 use crate::od::noise::GaussMarkov;
+use crate::od::process::FltResid;
 use crate::od::simulator::arc::TrackingArcSim;
 pub use crate::od::simulator::TrkConfig;
 pub use crate::{io::ConfigError, od::prelude::GroundStation};
@@ -45,6 +46,7 @@ pub(crate) fn register_od(py: Python<'_>, parent_module: &PyModule) -> PyResult<
     sm.add_class::<TrkConfig>()?;
     sm.add_class::<OrbitEstimate>()?;
     sm.add_class::<GaussMarkov>()?;
+    sm.add_class::<FltResid>()?;
     sm.add_function(wrap_pyfunction!(process_tracking_arc, sm)?)?;
 
     py_run!(

--- a/src/python/orbit_determination/process.rs
+++ b/src/python/orbit_determination/process.rs
@@ -61,6 +61,7 @@ pub(crate) fn process_tracking_arc(
         prop_est,
         kf,
         EkfTrigger::new(ekf_num_meas, ekf_disable_time),
+        RejectCriteria::None,
         Cosm::de438(),
     );
 

--- a/tests/orbit_determination/mod.rs
+++ b/tests/orbit_determination/mod.rs
@@ -8,6 +8,7 @@ use self::nyx::State;
 
 mod measurements;
 mod multi_body;
+mod resid_reject;
 mod robust;
 mod simulator;
 mod spacecraft;

--- a/tests/orbit_determination/mod.rs
+++ b/tests/orbit_determination/mod.rs
@@ -56,14 +56,14 @@ fn filter_errors() {
     let sensitivity = Matrix2x6::zeros();
 
     let mut ckf = KF::no_snc(initial_estimate, measurement_noise);
-    match ckf.measurement_update(Orbit::zeros(), real_obs, computed_obs) {
+    match ckf.measurement_update(Orbit::zeros(), real_obs, computed_obs, None) {
         Ok(_) => panic!("expected the measurement update to fail"),
         Err(e) => {
             assert_eq!(e, NyxError::SensitivityNotUpdated);
         }
     }
     ckf.update_h_tilde(sensitivity);
-    match ckf.measurement_update(Orbit::zeros(), real_obs, computed_obs) {
+    match ckf.measurement_update(Orbit::zeros(), real_obs, computed_obs, None) {
         Ok(_) => panic!("expected the measurement update to fail"),
         Err(e) => {
             assert_eq!(e, NyxError::SingularKalmanGain);

--- a/tests/orbit_determination/multi_body.rs
+++ b/tests/orbit_determination/multi_body.rs
@@ -109,8 +109,7 @@ fn od_val_multi_body_ckf_perfect_stations() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp =
-        ODProcess::<_, _, RangeDoppler, _, _, _, _>::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::<_, _, RangeDoppler, _, _, _, _>::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -245,7 +244,7 @@ fn multi_body_ckf_covar_map() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/multi_body.rs
+++ b/tests/orbit_determination/multi_body.rs
@@ -109,7 +109,8 @@ fn od_val_multi_body_ckf_perfect_stations() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::<_, _, RangeDoppler, _, _, _, _>::ckf(prop_est, ckf, cosm);
+    let mut odp =
+        ODProcess::<_, _, RangeDoppler, _, _, _, _>::ckf(prop_est, ckf, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -244,7 +245,7 @@ fn multi_body_ckf_covar_map() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/resid_reject.rs
+++ b/tests/orbit_determination/resid_reject.rs
@@ -1,0 +1,265 @@
+extern crate csv;
+extern crate nyx_space as nyx;
+extern crate pretty_env_logger;
+
+use nyx::cosmic::{Bodies, Cosm, Orbit};
+use nyx::dynamics::orbital::OrbitalDynamics;
+use nyx::io::formatter::NavSolutionFormatter;
+use nyx::linalg::{Matrix2, Vector2};
+use nyx::md::StateParameter;
+use nyx::od::noise::GaussMarkov;
+use nyx::od::prelude::*;
+use nyx::propagators::{PropOpts, Propagator, RK4Fixed};
+use nyx::time::{Epoch, TimeUnits};
+use nyx::utils::rss_orbit_errors;
+use std::collections::HashMap;
+
+// TODO: Convert to rstest for the truth trajectory and the different set ups
+
+#[allow(clippy::identity_op)]
+#[test]
+fn od_resid_reject_ckf_two_way() {
+    if pretty_env_logger::try_init().is_err() {
+        println!("could not init env_logger");
+    }
+
+    let cosm = Cosm::de438();
+
+    let iau_earth = cosm.frame("IAU Earth");
+    let elevation_mask = 0.0;
+
+    // Define the propagator information.
+    let prop_time = 2.hours();
+    let step_size = 10.0.seconds();
+    let opts = PropOpts::with_fixed_step(step_size);
+
+    // Define state information.
+    let eme2k = cosm.frame("EME2000");
+    let dt = Epoch::from_gregorian_tai_at_midnight(2023, 1, 1);
+    let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
+
+    let mut dss65_madrid = GroundStation::dss65_madrid(
+        elevation_mask,
+        GaussMarkov::high_precision_range_km(),
+        GaussMarkov::high_precision_doppler_km_s(),
+        iau_earth,
+    );
+    // Set the integration time so as to generate two way measurements
+    dss65_madrid.integration_time = Some(60.seconds());
+    let mut dss34_canberra = GroundStation::dss34_canberra(
+        elevation_mask,
+        GaussMarkov::high_precision_range_km(),
+        GaussMarkov::high_precision_doppler_km_s(),
+        iau_earth,
+    );
+    dss34_canberra.integration_time = Some(60.seconds());
+
+    // Define the tracking configurations
+    let mut configs = HashMap::new();
+    configs.insert(
+        dss65_madrid.name.clone(),
+        TrkConfig {
+            // Make sure to start the tracking one integration time after the start of the trajectory
+            start: simulator::Availability::Epoch(dt + 60.seconds()),
+            sampling: 60.seconds(),
+            ..Default::default()
+        },
+    );
+    configs.insert(
+        dss34_canberra.name.clone(),
+        TrkConfig {
+            // Make sure to start the tracking one integration time after the start of the trajectory
+            start: simulator::Availability::Epoch(dt + 60.seconds()),
+            sampling: 60.seconds(),
+            ..Default::default()
+        },
+    );
+
+    // Note that we do not have Goldstone so we can test enabling and disabling the EKF.
+    let devices = vec![dss65_madrid, dss34_canberra];
+
+    let initial_estimate = KfEstimate::disperse_from_diag(
+        initial_state,
+        &[
+            (StateParameter::SMA, 30.0),
+            (StateParameter::Inclination, 0.025),
+            (StateParameter::RAAN, 0.22),
+        ],
+        Some(10),
+    );
+    println!("Initial estimate:\n{}", initial_estimate);
+
+    let initial_state_dev = initial_estimate.nominal_state;
+    let (init_rss_pos_km, init_rss_vel_km_s) = rss_orbit_errors(&initial_state, &initial_state_dev);
+
+    println!("Truth initial state:\n{initial_state}\n{initial_state:x}");
+    println!("Filter initial state:\n{initial_state_dev}\n{initial_state_dev:x}");
+    println!(
+        "Initial state dev:\t{:.3} km\t{:.3} km/s\n{}",
+        init_rss_pos_km * 1e3,
+        init_rss_vel_km_s * 1e3,
+        initial_state - initial_state_dev
+    );
+
+    let bodies = vec![
+        Bodies::Luna,
+        Bodies::Sun,
+        Bodies::JupiterBarycenter,
+        Bodies::SaturnBarycenter,
+    ];
+    let orbital_dyn = OrbitalDynamics::point_masses(&bodies, cosm.clone());
+    let truth_setup = Propagator::dp78(orbital_dyn, PropOpts::with_max_step(step_size));
+    let (_, traj) = truth_setup
+        .with(initial_state)
+        .for_duration_with_traj(prop_time)
+        .unwrap();
+
+    // Simulate tracking data
+    let mut arc_sim = TrackingArcSim::with_seed(devices.clone(), traj.clone(), configs, 0).unwrap();
+    arc_sim.disallow_overlap(); // Prevent overlapping measurements
+
+    let arc = arc_sim.generate_measurements(cosm.clone()).unwrap();
+
+    println!("{arc}");
+
+    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
+    // We expect the estimated orbit to be _nearly_ perfect because we've removed Saturn from the estimated trajectory
+    let bodies = vec![Bodies::Luna, Bodies::Sun, Bodies::JupiterBarycenter];
+    let estimator = OrbitalDynamics::point_masses(&bodies, cosm.clone());
+    let setup = Propagator::new::<RK4Fixed>(estimator, opts);
+    let prop_est = setup.with(initial_state_dev.with_stm());
+
+    // Define the expected measurement noise (we will then expect the residuals to be within those bounds if we have correctly set up the filter)
+    let measurement_noise = Matrix2::from_diagonal(&Vector2::new(1e-6, 1e-3));
+
+    // Define the process noise to assume an unmodeled acceleration on X, Y and Z in the ECI frame
+    let sigma_q = 5e-10_f64.powi(2);
+    let process_noise = SNC3::from_diagonal(2.minutes(), &[sigma_q, sigma_q, sigma_q]);
+
+    let kf = KF::new(initial_estimate, process_noise, measurement_noise);
+
+    let mut odp = ODProcess::ckf(
+        prop_est,
+        kf,
+        RejectCriteria::ResidualRatio {
+            count: 1,
+            value: 3.0,
+        },
+        cosm.clone(),
+    );
+
+    // TODO: Fix the deserialization of the measurements such that they also deserialize the integration time.
+    // Without it, we're stuck having to rebuild them from scratch.
+    // https://github.com/nyx-space/nyx/issues/140
+
+    // Build the hashmap of devices from the vector using their names
+    let mut devices_map = devices
+        .into_iter()
+        .map(|dev| (dev.name.clone(), dev))
+        .collect::<HashMap<_, _>>();
+
+    odp.process(
+        &arc.measurements,
+        &mut devices_map,
+        arc.min_duration_sep().unwrap(),
+    )
+    .unwrap();
+
+    let estimate_fmtr =
+        NavSolutionFormatter::default("robustness_test_two_way.csv".to_owned(), cosm);
+
+    let mut wtr = csv::Writer::from_path("robustness_test_two_way.csv").unwrap();
+    wtr.serialize(&estimate_fmtr.headers)
+        .expect("could not write to output file");
+
+    let mut err_wtr = csv::Writer::from_path("resid_reject_two_way_estimates.csv").unwrap();
+    err_wtr
+        .serialize(vec![
+            "epoch",
+            "x_err_km",
+            "y_err_km",
+            "z_err_km",
+            "vx_err_km_s",
+            "vy_err_km_s",
+            "vz_err_km_s",
+        ])
+        .expect("could not write to output file");
+
+    for est in &odp.estimates {
+        // Format the estimate
+        wtr.serialize(estimate_fmtr.fmt(est))
+            .expect("could not write to CSV");
+        // Add the error data
+        let truth_state = traj.at(est.epoch()).unwrap();
+        let err = truth_state - est.state();
+        err_wtr
+            .serialize(vec![
+                est.epoch().to_string(),
+                format!("{}", err.x_km),
+                format!("{}", err.y_km),
+                format!("{}", err.z_km),
+                format!("{}", err.vx_km_s),
+                format!("{}", err.vy_km_s),
+                format!("{}", err.vz_km_s),
+            ])
+            .expect("could not write to CSV");
+    }
+
+    let mut resid_wtr = csv::Writer::from_path("resid_reject_two_way_residuals.csv").unwrap();
+    resid_wtr
+        .serialize(vec![
+            "epoch",
+            "range_prefit",
+            "doppler_prefit",
+            "range_postfit",
+            "doppler_postfit",
+            "residual_ratio",
+        ])
+        .expect("could not write to output file");
+
+    for res in &odp.residuals {
+        resid_wtr
+            .serialize(vec![
+                res.epoch.to_string(),
+                format!("{}", res.prefit[0]),
+                format!("{}", res.prefit[1]),
+                format!("{}", res.postfit[0]),
+                format!("{}", res.postfit[1]),
+                format!("{}", res.ratio),
+            ])
+            .expect("could not write to CSV");
+    }
+
+    // Check that the covariance deflated
+    let est = &odp.estimates[odp.estimates.len() - 1];
+    let final_truth_state = traj.at(est.epoch()).unwrap();
+
+    println!("Estimate:\n{}", est);
+    println!("Truth:\n{}", final_truth_state);
+    println!(
+        "Delta state with truth (epoch match: {}):\n{}",
+        final_truth_state.epoch == est.epoch(),
+        final_truth_state - est.state()
+    );
+
+    assert_eq!(
+        final_truth_state.epoch,
+        est.epoch(),
+        "time of final EST and TRUTH epochs differ"
+    );
+    let delta = est.state() - final_truth_state;
+    println!(
+        "RMAG error = {:.6} m\tVMAG error = {:.6} m/s",
+        delta.rmag_km() * 1e3,
+        delta.vmag_km_s() * 1e3
+    );
+
+    assert!(
+        delta.rmag_km() < 0.01,
+        "Position error should be less than 10 meters"
+    );
+    assert!(
+        delta.vmag_km_s() < 1e-5,
+        "Velocity error should be on centimeter level"
+    );
+}

--- a/tests/orbit_determination/resid_reject.rs
+++ b/tests/orbit_determination/resid_reject.rs
@@ -1,43 +1,67 @@
 extern crate csv;
-extern crate nyx_space as nyx;
-extern crate pretty_env_logger;
 
-use nyx::cosmic::{Bodies, Cosm, Orbit};
-use nyx::dynamics::orbital::OrbitalDynamics;
-use nyx::io::formatter::NavSolutionFormatter;
-use nyx::linalg::{Matrix2, Vector2};
-use nyx::md::StateParameter;
-use nyx::od::noise::GaussMarkov;
-use nyx::od::prelude::*;
-use nyx::propagators::{PropOpts, Propagator, RK4Fixed};
-use nyx::time::{Epoch, TimeUnits};
-use nyx::utils::rss_orbit_errors;
+use pretty_env_logger::try_init;
+
+use rstest::*;
+
+use nyx_space::cosmic::{Bodies, Cosm, Orbit};
+use nyx_space::dynamics::orbital::OrbitalDynamics;
+use nyx_space::linalg::{Matrix2, Vector2};
+use nyx_space::md::ui::*;
+use nyx_space::md::StateParameter;
+use nyx_space::od::noise::GaussMarkov;
+use nyx_space::od::prelude::*;
+use nyx_space::propagators::{PropOpts, Propagator, RK4Fixed};
+use nyx_space::time::{Epoch, TimeUnits};
+use nyx_space::utils::rss_orbit_errors;
 use std::collections::HashMap;
 
-// TODO: Convert to rstest for the truth trajectory and the different set ups
+#[fixture]
+fn epoch() -> Epoch {
+    Epoch::from_gregorian_tai_at_midnight(2023, 1, 1)
+}
 
-#[allow(clippy::identity_op)]
-#[test]
-fn od_resid_reject_ckf_two_way() {
-    if pretty_env_logger::try_init().is_err() {
-        println!("could not init env_logger");
-    }
+#[fixture]
+fn traj(epoch: Epoch) -> Traj<Orbit> {
+    if try_init().is_err() {}
 
+    // Load cosm
     let cosm = Cosm::de438();
-
-    let iau_earth = cosm.frame("IAU Earth");
-    let elevation_mask = 0.0;
 
     // Define the propagator information.
     let prop_time = 2.hours();
     let step_size = 10.0.seconds();
-    let opts = PropOpts::with_fixed_step(step_size);
 
     // Define state information.
     let eme2k = cosm.frame("EME2000");
-    let dt = Epoch::from_gregorian_tai_at_midnight(2023, 1, 1);
-    let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
+    let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, epoch, eme2k);
 
+    let bodies = vec![
+        Bodies::Luna,
+        Bodies::Sun,
+        Bodies::JupiterBarycenter,
+        Bodies::SaturnBarycenter,
+    ];
+    let orbital_dyn = OrbitalDynamics::point_masses(&bodies, cosm.clone());
+    let truth_setup = Propagator::dp78(orbital_dyn, PropOpts::with_max_step(step_size));
+    let (_, traj) = truth_setup
+        .with(initial_state)
+        .for_duration_with_traj(prop_time)
+        .unwrap();
+
+    traj
+}
+
+#[fixture]
+fn devices_n_configs(epoch: Epoch) -> (Vec<GroundStation>, HashMap<String, TrkConfig>) {
+    // Load cosm
+    let cosm = Cosm::de438();
+
+    let iau_earth = cosm.frame("IAU Earth");
+
+    let elevation_mask = 0.0;
+
+    // Define the ground stations
     let mut dss65_madrid = GroundStation::dss65_madrid(
         elevation_mask,
         GaussMarkov::high_precision_range_km(),
@@ -60,7 +84,7 @@ fn od_resid_reject_ckf_two_way() {
         dss65_madrid.name.clone(),
         TrkConfig {
             // Make sure to start the tracking one integration time after the start of the trajectory
-            start: simulator::Availability::Epoch(dt + 60.seconds()),
+            start: simulator::Availability::Epoch(epoch + 60.seconds()),
             sampling: 60.seconds(),
             ..Default::default()
         },
@@ -69,14 +93,39 @@ fn od_resid_reject_ckf_two_way() {
         dss34_canberra.name.clone(),
         TrkConfig {
             // Make sure to start the tracking one integration time after the start of the trajectory
-            start: simulator::Availability::Epoch(dt + 60.seconds()),
+            start: simulator::Availability::Epoch(epoch + 60.seconds()),
             sampling: 60.seconds(),
             ..Default::default()
         },
     );
 
-    // Note that we do not have Goldstone so we can test enabling and disabling the EKF.
-    let devices = vec![dss65_madrid, dss34_canberra];
+    (vec![dss65_madrid, dss34_canberra], configs)
+}
+
+#[fixture]
+fn tracking_arc(
+    traj: Traj<Orbit>,
+    devices_n_configs: (Vec<GroundStation>, HashMap<String, TrkConfig>),
+) -> TrackingArc<RangeDoppler> {
+    // Load cosm
+    let cosm = Cosm::de438();
+
+    let (devices, configs) = devices_n_configs;
+
+    // Simulate tracking data
+    let mut arc_sim = TrackingArcSim::with_seed(devices, traj, configs, 0).unwrap();
+    arc_sim.disallow_overlap(); // Prevent overlapping measurements
+
+    let arc = arc_sim.generate_measurements(cosm).unwrap();
+
+    println!("{arc}");
+
+    arc
+}
+
+#[fixture]
+fn initial_estimate(traj: Traj<Orbit>) -> KfEstimate<Orbit> {
+    let initial_state = *(traj.first());
 
     let initial_estimate = KfEstimate::disperse_from_diag(
         initial_state,
@@ -95,38 +144,33 @@ fn od_resid_reject_ckf_two_way() {
     println!("Truth initial state:\n{initial_state}\n{initial_state:x}");
     println!("Filter initial state:\n{initial_state_dev}\n{initial_state_dev:x}");
     println!(
-        "Initial state dev:\t{:.3} km\t{:.3} km/s\n{}",
+        "Initial state dev:\t{:.3} m\t{:.3} m/s\n{}",
         init_rss_pos_km * 1e3,
         init_rss_vel_km_s * 1e3,
         initial_state - initial_state_dev
     );
 
-    let bodies = vec![
-        Bodies::Luna,
-        Bodies::Sun,
-        Bodies::JupiterBarycenter,
-        Bodies::SaturnBarycenter,
-    ];
-    let orbital_dyn = OrbitalDynamics::point_masses(&bodies, cosm.clone());
-    let truth_setup = Propagator::dp78(orbital_dyn, PropOpts::with_max_step(step_size));
-    let (_, traj) = truth_setup
-        .with(initial_state)
-        .for_duration_with_traj(prop_time)
-        .unwrap();
+    initial_estimate
+}
 
-    // Simulate tracking data
-    let mut arc_sim = TrackingArcSim::with_seed(devices.clone(), traj.clone(), configs, 0).unwrap();
-    arc_sim.disallow_overlap(); // Prevent overlapping measurements
+#[rstest]
+fn od_resid_reject_all_ckf_two_way(
+    tracking_arc: TrackingArc<RangeDoppler>,
+    initial_estimate: KfEstimate<Orbit>,
+    devices_n_configs: (Vec<GroundStation>, HashMap<String, TrkConfig>),
+) {
+    // Load cosm
+    let cosm = Cosm::de438();
 
-    let arc = arc_sim.generate_measurements(cosm.clone()).unwrap();
+    let (devices, _configs) = devices_n_configs;
 
-    println!("{arc}");
+    let initial_state_dev = initial_estimate.nominal_state;
 
     // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
     // We expect the estimated orbit to be _nearly_ perfect because we've removed Saturn from the estimated trajectory
     let bodies = vec![Bodies::Luna, Bodies::Sun, Bodies::JupiterBarycenter];
     let estimator = OrbitalDynamics::point_masses(&bodies, cosm.clone());
-    let setup = Propagator::new::<RK4Fixed>(estimator, opts);
+    let setup = Propagator::new::<RK4Fixed>(estimator, PropOpts::with_fixed_step(10.seconds()));
     let prop_est = setup.with(initial_state_dev.with_stm());
 
     // Define the expected measurement noise (we will then expect the residuals to be within those bounds if we have correctly set up the filter)
@@ -138,13 +182,18 @@ fn od_resid_reject_ckf_two_way() {
 
     let kf = KF::new(initial_estimate, process_noise, measurement_noise);
 
+    // ==> TEST <== //
+    // We set up the rejection criteria to start after a single measurement and with a residual ratio of 3.0, i.e. within 3-sigmas.
+    // The initial dispersion is about 20388 km, so we none of the residuals will be within those 3-sigmas.
+    // Therefore, the test is to confirm that the ODP only performs time updates and zero measurement updates.
+
     let mut odp = ODProcess::ckf(
         prop_est,
         kf,
-        RejectCriteria::ResidualRatio {
-            count: 1,
-            value: 3.0,
-        },
+        Some(FltResid {
+            min_accepted: 0, // Start the preprocessing filter at the first measurement because we try to filter everything out in this test
+            num_sigmas: 3.0,
+        }),
         cosm.clone(),
     );
 
@@ -159,75 +208,80 @@ fn od_resid_reject_ckf_two_way() {
         .collect::<HashMap<_, _>>();
 
     odp.process(
-        &arc.measurements,
+        &tracking_arc.measurements,
         &mut devices_map,
-        arc.min_duration_sep().unwrap(),
+        tracking_arc.min_duration_sep().unwrap(),
     )
     .unwrap();
 
-    let estimate_fmtr =
-        NavSolutionFormatter::default("robustness_test_two_way.csv".to_owned(), cosm);
-
-    let mut wtr = csv::Writer::from_path("robustness_test_two_way.csv").unwrap();
-    wtr.serialize(&estimate_fmtr.headers)
-        .expect("could not write to output file");
-
-    let mut err_wtr = csv::Writer::from_path("resid_reject_two_way_estimates.csv").unwrap();
-    err_wtr
-        .serialize(vec![
-            "epoch",
-            "x_err_km",
-            "y_err_km",
-            "z_err_km",
-            "vx_err_km_s",
-            "vy_err_km_s",
-            "vz_err_km_s",
-        ])
-        .expect("could not write to output file");
-
-    for est in &odp.estimates {
-        // Format the estimate
-        wtr.serialize(estimate_fmtr.fmt(est))
-            .expect("could not write to CSV");
-        // Add the error data
-        let truth_state = traj.at(est.epoch()).unwrap();
-        let err = truth_state - est.state();
-        err_wtr
-            .serialize(vec![
-                est.epoch().to_string(),
-                format!("{}", err.x_km),
-                format!("{}", err.y_km),
-                format!("{}", err.z_km),
-                format!("{}", err.vx_km_s),
-                format!("{}", err.vy_km_s),
-                format!("{}", err.vz_km_s),
-            ])
-            .expect("could not write to CSV");
+    for residual in odp.residuals.iter() {
+        assert!(residual.rejected, "{} was not rejected!", residual.epoch);
     }
 
-    let mut resid_wtr = csv::Writer::from_path("resid_reject_two_way_residuals.csv").unwrap();
-    resid_wtr
-        .serialize(vec![
-            "epoch",
-            "range_prefit",
-            "doppler_prefit",
-            "range_postfit",
-            "doppler_postfit",
-            "residual_ratio",
-        ])
-        .expect("could not write to output file");
+    for estimate in odp.estimates.iter() {
+        assert!(
+            estimate.predicted,
+            "{} was not predicted!",
+            estimate.epoch()
+        );
+    }
 
-    for res in &odp.residuals {
-        resid_wtr
-            .serialize(vec![
-                res.epoch.to_string(),
-                format!("{}", res.prefit[0]),
-                format!("{}", res.prefit[1]),
-                format!("{}", res.postfit[0]),
-                format!("{}", res.postfit[1]),
-                format!("{}", res.ratio),
-            ])
-            .expect("could not write to CSV");
+    // We don't check the estimation because it'll be bad since we rejected all the measurements.
+}
+
+#[rstest]
+fn od_resid_reject_default_ckf_two_way(
+    traj: Traj<Orbit>,
+    tracking_arc: TrackingArc<RangeDoppler>,
+    initial_estimate: KfEstimate<Orbit>,
+    devices_n_configs: (Vec<GroundStation>, HashMap<String, TrkConfig>),
+) {
+    // Load cosm
+    let cosm = Cosm::de438();
+
+    let (devices, _configs) = devices_n_configs;
+
+    let initial_state_dev = initial_estimate.nominal_state;
+
+    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
+    // We expect the estimated orbit to be _nearly_ perfect because we've removed Saturn from the estimated trajectory
+    let bodies = vec![Bodies::Luna, Bodies::Sun, Bodies::JupiterBarycenter];
+    let estimator = OrbitalDynamics::point_masses(&bodies, cosm.clone());
+    let setup = Propagator::new::<RK4Fixed>(estimator, PropOpts::with_fixed_step(10.seconds()));
+    let prop_est = setup.with(initial_state_dev.with_stm());
+
+    // Define the expected measurement noise (we will then expect the residuals to be within those bounds if we have correctly set up the filter)
+    let measurement_noise = Matrix2::from_diagonal(&Vector2::new(1e-6, 1e-3));
+
+    // Define the process noise to assume an unmodeled acceleration on X, Y and Z in the ECI frame
+    let sigma_q = 5e-10_f64.powi(2);
+    let process_noise = SNC3::from_diagonal(2.minutes(), &[sigma_q, sigma_q, sigma_q]);
+
+    let kf = KF::new(initial_estimate, process_noise, measurement_noise);
+
+    let mut odp = ODProcess::ckf(prop_est, kf, Some(FltResid::default()), cosm.clone());
+
+    // TODO: Fix the deserialization of the measurements such that they also deserialize the integration time.
+    // Without it, we're stuck having to rebuild them from scratch.
+    // https://github.com/nyx-space/nyx/issues/140
+
+    // Build the hashmap of devices from the vector using their names
+    let mut devices_map = devices
+        .into_iter()
+        .map(|dev| (dev.name.clone(), dev))
+        .collect::<HashMap<_, _>>();
+
+    odp.process(
+        &tracking_arc.measurements,
+        &mut devices_map,
+        tracking_arc.min_duration_sep().unwrap(),
+    )
+    .unwrap();
+
+    // With the default configuration, the filter converges very fast since we have similar dynamics.
+
+    for residual in odp.residuals.iter() {
+        assert!(!residual.rejected, "{} was rejected!", residual.epoch);
     }
 
     // Check that the covariance deflated
@@ -254,12 +308,15 @@ fn od_resid_reject_ckf_two_way() {
         delta.vmag_km_s() * 1e3
     );
 
+    // We start with a 20 km error and with only 120 measurements, no iteration, and no extended KF, we achieve less than 500 meters of error.
+    // That's not bad!
+
     assert!(
-        delta.rmag_km() < 0.01,
-        "Position error should be less than 10 meters"
+        delta.rmag_km() < 0.5,
+        "Position error should be less than 500 meters"
     );
     assert!(
-        delta.vmag_km_s() < 1e-5,
-        "Velocity error should be on centimeter level"
+        delta.vmag_km_s() < 1e-3,
+        "Velocity error should be on meter per second level"
     );
 }

--- a/tests/orbit_determination/robust.rs
+++ b/tests/orbit_determination/robust.rs
@@ -95,7 +95,7 @@ fn od_robust_test_ekf_realistic_one_way() {
     println!("Truth initial state:\n{initial_state}\n{initial_state:x}");
     println!("Filter initial state:\n{initial_state_dev}\n{initial_state_dev:x}");
     println!(
-        "Initial state dev:\t{:.3} km\t{:.3} km/s\n{}",
+        "Initial state dev:\t{:.3} m\t{:.3} m/s\n{}",
         init_rss_pos_km * 1e3,
         init_rss_vel_km_s * 1e3,
         initial_state - initial_state_dev
@@ -149,7 +149,7 @@ fn od_robust_test_ekf_realistic_one_way() {
 
     let trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm.clone());
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, None, cosm.clone());
 
     // Let's filter and iterate on the initial subset of the arc to refine the initial estimate
     let subset = arc.filter_by_offset(..3.hours());
@@ -372,7 +372,7 @@ fn od_robust_test_ekf_realistic_two_way() {
     println!("Truth initial state:\n{initial_state}\n{initial_state:x}");
     println!("Filter initial state:\n{initial_state_dev}\n{initial_state_dev:x}");
     println!(
-        "Initial state dev:\t{:.3} km\t{:.3} km/s\n{}",
+        "Initial state dev:\t{:.3} m\t{:.3} m/s\n{}",
         init_rss_pos_km * 1e3,
         init_rss_vel_km_s * 1e3,
         initial_state - initial_state_dev
@@ -428,7 +428,7 @@ fn od_robust_test_ekf_realistic_two_way() {
 
     let trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm.clone());
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, None, cosm.clone());
 
     // TODO: Fix the deserialization of the measurements such that they also deserialize the integration time.
     // Without it, we're stuck having to rebuild them from scratch.

--- a/tests/orbit_determination/robust.rs
+++ b/tests/orbit_determination/robust.rs
@@ -149,7 +149,7 @@ fn od_robust_test_ekf_realistic_one_way() {
 
     let trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, cosm.clone());
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm.clone());
 
     // Let's filter and iterate on the initial subset of the arc to refine the initial estimate
     let subset = arc.filter_by_offset(..3.hours());
@@ -225,7 +225,7 @@ fn od_robust_test_ekf_realistic_one_way() {
     for res in &odp.residuals {
         resid_wtr
             .serialize(vec![
-                res.dt.to_string(),
+                res.epoch.to_string(),
                 format!("{}", res.prefit[0]),
                 format!("{}", res.prefit[1]),
                 format!("{}", res.postfit[0]),
@@ -428,7 +428,7 @@ fn od_robust_test_ekf_realistic_two_way() {
 
     let trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, cosm.clone());
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm.clone());
 
     // TODO: Fix the deserialization of the measurements such that they also deserialize the integration time.
     // Without it, we're stuck having to rebuild them from scratch.
@@ -502,7 +502,7 @@ fn od_robust_test_ekf_realistic_two_way() {
     for res in &odp.residuals {
         resid_wtr
             .serialize(vec![
-                res.dt.to_string(),
+                res.epoch.to_string(),
                 format!("{}", res.prefit[0]),
                 format!("{}", res.prefit[1]),
                 format!("{}", res.postfit[0]),

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -171,7 +171,7 @@ fn od_val_sc_mb_srp_reals_duals_models() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm.clone());
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm.clone());
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -171,7 +171,7 @@ fn od_val_sc_mb_srp_reals_duals_models() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, cosm.clone());
+    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm.clone());
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/two_body.rs
+++ b/tests/orbit_determination/two_body.rs
@@ -120,10 +120,7 @@ fn od_tb_val_ekf_fixed_step_perfect_stations() {
         prop_est,
         kf,
         EkfTrigger::new(ekf_num_meas, ekf_disable_time),
-        RejectCriteria::ZScoreMultiplier {
-            count: 100,
-            value: 3.0,
-        },
+        None,
         cosm,
     );
 
@@ -293,10 +290,7 @@ fn od_tb_val_with_arc() {
         prop_est,
         kf,
         EkfTrigger::new(ekf_num_meas, ekf_disable_time),
-        RejectCriteria::ResidualRatio {
-            count: 100,
-            value: 3.0,
-        },
+        Some(FltResid::default()),
         cosm,
     );
 
@@ -456,7 +450,7 @@ fn od_tb_val_ckf_fixed_step_perfect_stations() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm.clone());
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm.clone());
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -704,7 +698,7 @@ fn od_tb_ckf_fixed_step_iteration_test() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -873,7 +867,7 @@ fn od_tb_ckf_fixed_step_perfect_stations_snc_covar_map() {
 
     let ckf = KF::new(initial_estimate, process_noise, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -976,7 +970,7 @@ fn od_tb_ckf_map_covar() {
         nalgebra::Const<3>,
         Orbit,
         KF<Orbit, nalgebra::Const<3>, nalgebra::Const<2>>,
-    > = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    > = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.map_covar(dt + prop_time).unwrap();
 
@@ -1105,7 +1099,7 @@ fn od_tb_val_harmonics_ckf_fixed_step_perfect() {
 
     let ckf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
     let mut wtr = csv::Writer::from_path("./estimation.csv").unwrap();
@@ -1258,7 +1252,7 @@ fn od_tb_ckf_fixed_step_perfect_stations_several_snc_covar_map() {
         measurement_noise,
     );
 
-    let mut odp = ODProcess::ckf(prop_est, ckf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, ckf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/xhat_dev.rs
+++ b/tests/orbit_determination/xhat_dev.rs
@@ -119,7 +119,7 @@ fn xhat_dev_test_ekf_two_body() {
     let process_noise = SNC3::from_diagonal(2 * Unit::Minute, &[sigma_q, sigma_q, sigma_q]);
     let kf = KF::new(initial_estimate, process_noise, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
     let pre_smooth_first_est = odp.estimates[0];
@@ -334,7 +334,7 @@ fn xhat_dev_test_ekf_multi_body() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
     odp.iterate_arc::<GroundStation>(&arc, IterationConf::try_from(SmoothingArc::All).unwrap())
@@ -513,7 +513,7 @@ fn xhat_dev_test_ekf_harmonics() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -666,7 +666,7 @@ fn xhat_dev_test_ekf_realistic() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -816,7 +816,7 @@ fn xhat_dev_test_ckf_smoother_multi_body() {
 
     let kf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -1100,6 +1100,7 @@ fn xhat_dev_test_ekf_snc_smoother_multi_body() {
         prop_est,
         kf,
         EkfTrigger::new(ekf_num_meas, ekf_disable_time),
+        RejectCriteria::None,
         cosm,
     );
 
@@ -1360,7 +1361,7 @@ fn xhat_dev_test_ckf_iteration_multi_body() {
 
     let kf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 

--- a/tests/orbit_determination/xhat_dev.rs
+++ b/tests/orbit_determination/xhat_dev.rs
@@ -119,7 +119,7 @@ fn xhat_dev_test_ekf_two_body() {
     let process_noise = SNC3::from_diagonal(2 * Unit::Minute, &[sigma_q, sigma_q, sigma_q]);
     let kf = KF::new(initial_estimate, process_noise, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
     let pre_smooth_first_est = odp.estimates[0];
@@ -334,7 +334,7 @@ fn xhat_dev_test_ekf_multi_body() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
     odp.iterate_arc::<GroundStation>(&arc, IterationConf::try_from(SmoothingArc::All).unwrap())
@@ -513,7 +513,7 @@ fn xhat_dev_test_ekf_harmonics() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -666,7 +666,7 @@ fn xhat_dev_test_ekf_realistic() {
     let mut trig = EkfTrigger::new(ekf_num_meas, ekf_disable_time);
     trig.within_sigma = 3.0;
 
-    let mut odp = ODProcess::ekf(prop_est, kf, trig, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ekf(prop_est, kf, trig, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -816,7 +816,7 @@ fn xhat_dev_test_ckf_smoother_multi_body() {
 
     let kf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 
@@ -1100,7 +1100,7 @@ fn xhat_dev_test_ekf_snc_smoother_multi_body() {
         prop_est,
         kf,
         EkfTrigger::new(ekf_num_meas, ekf_disable_time),
-        RejectCriteria::None,
+        None,
         cosm,
     );
 
@@ -1361,7 +1361,7 @@ fn xhat_dev_test_ckf_iteration_multi_body() {
 
     let kf = KF::no_snc(initial_estimate, measurement_noise);
 
-    let mut odp = ODProcess::ckf(prop_est, kf, RejectCriteria::None, cosm);
+    let mut odp = ODProcess::ckf(prop_est, kf, None, cosm);
 
     odp.process_arc::<GroundStation>(&arc).unwrap();
 


### PR DESCRIPTION
### Effects

Add the ability to reject measurements online prior to ingesting them in the filter. When rejected, a warning is printed and the filter performs a time update instead.

### If this is a new feature or a bug fix ...
- [x] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [x] No.

TODO:
- [x] Add test of rejection
- [x] Add ability to configure via Python (can be configured in YAML but not used in Python yet -- should be a path to a YAML file)

Closes #127