### PR TITLE
(feat) improve `rss_errors()` using a functional programming approach

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -208,7 +208,7 @@ pub fn projv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
 ///
 /// # Returns
 ///
-/// * A f64 value representing the RSS state error.
+/// A f64 value representing the RSS state error.
 pub fn rss_errors<N: DimName>(prop_err: &OVector<f64, N>, cur_state: &OVector<f64, N>) -> f64
 where
     DefaultAllocator: Allocator<f64, N>,
@@ -230,7 +230,7 @@ where
 ///
 /// # Returns
 ///
-/// * A tuple of f64 values representing the RSS orbit errors in radius and velocity.
+/// A tuple of f64 values representing the RSS orbit errors in radius and velocity.
 pub fn rss_orbit_errors(prop_err: &Orbit, cur_state: &Orbit) -> (f64, f64) {
     (
         rss_errors(&prop_err.radius(), &cur_state.radius()),
@@ -247,7 +247,7 @@ pub fn rss_orbit_errors(prop_err: &Orbit, cur_state: &Orbit) -> (f64, f64) {
 ///
 /// # Returns
 ///
-/// * A tuple of f64 values representing the RSS orbit vector errors in radius and velocity.
+/// A tuple of f64 values representing the RSS orbit vector errors in radius and velocity.
 pub fn rss_orbit_vec_errors(prop_err: &Vector6<f64>, cur_state: &Vector6<f64>) -> (f64, f64) {
     let err_radius = (prop_err.fixed_rows::<3>(0) - cur_state.fixed_rows::<3>(0)).norm();
     let err_velocity = (prop_err.fixed_rows::<3>(3) - cur_state.fixed_rows::<3>(3)).norm();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -221,6 +221,18 @@ where
         .sqrt()
 }
 
+#[test]
+fn test_rss_errors() {
+    use nalgebra::U3;
+    let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+    let cur_state = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+    assert_eq!(rss_errors(&prop_err, &cur_state), 0.0);
+
+    let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+    let cur_state = OVector::<f64, U3>::from_iterator([4.0, 5.0, 6.0]);
+    assert_eq!(rss_errors(&prop_err, &cur_state), 5.196152422706632);
+}
+
 /// Computes the Root Sum Squared (RSS) orbit errors in kilometers and kilometers per second.
 ///
 /// # Arguments

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -199,19 +199,38 @@ pub fn projv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
     b * a.dot(b) / b.dot(b)
 }
 
-/// Computes the RSS state errors in two provided vectors
+/// Computes the Root Sum Squared (RSS) state errors between two provided vectors.
+///
+/// # Arguments
+///
+/// * `prop_err` - A vector representing the propagated error.
+/// * `cur_state` - A vector representing the current state.
+///
+/// # Returns
+///
+/// * A f64 value representing the RSS state error.
 pub fn rss_errors<N: DimName>(prop_err: &OVector<f64, N>, cur_state: &OVector<f64, N>) -> f64
 where
     DefaultAllocator: Allocator<f64, N>,
 {
-    let mut v = 0.0;
-    for i in 0..N::dim() {
-        v += (prop_err[i] - cur_state[i]).powi(2);
-    }
-    v.sqrt()
+    prop_err
+        .iter()
+        .zip(cur_state.iter())
+        .map(|(&x, &y)| (x - y).powi(2))
+        .sum::<f64>()
+        .sqrt()
 }
 
-/// Returns the RSS orbit errors in kilometers and kilometers per second
+/// Computes the Root Sum Squared (RSS) orbit errors in kilometers and kilometers per second.
+///
+/// # Arguments
+///
+/// * `prop_err` - An Orbit instance representing the propagated error.
+/// * `cur_state` - An Orbit instance representing the current state.
+///
+/// # Returns
+///
+/// * A tuple of f64 values representing the RSS orbit errors in radius and velocity.
 pub fn rss_orbit_errors(prop_err: &Orbit, cur_state: &Orbit) -> (f64, f64) {
     (
         rss_errors(&prop_err.radius(), &cur_state.radius()),
@@ -219,12 +238,19 @@ pub fn rss_orbit_errors(prop_err: &Orbit, cur_state: &Orbit) -> (f64, f64) {
     )
 }
 
-/// Computes the RSS state errors in position and in velocity of two orbit vectors [P V]
+/// Computes the Root Sum Squared (RSS) state errors in position and in velocity of two orbit vectors [P V].
+///
+/// # Arguments
+///
+/// * `prop_err` - A Vector6 instance representing the propagated error.
+/// * `cur_state` - A Vector6 instance representing the current state.
+///
+/// # Returns
+///
+/// * A tuple of f64 values representing the RSS orbit vector errors in radius and velocity.
 pub fn rss_orbit_vec_errors(prop_err: &Vector6<f64>, cur_state: &Vector6<f64>) -> (f64, f64) {
     let err_radius = (prop_err.fixed_rows::<3>(0) - cur_state.fixed_rows::<3>(0)).norm();
-
     let err_velocity = (prop_err.fixed_rows::<3>(3) - cur_state.fixed_rows::<3>(3)).norm();
-
     (err_radius, err_velocity)
 }
 


### PR DESCRIPTION
- Improve docstrings on `rss_*` utility functions from `utils.rs`
- Make `rss_errors` kind of more idiomatic using a functional programming way

I tried to put some UT but I did not well understood how to do them.

For example, we could have:

```rs
    #[test]
    fn test_rss_errors() {
        let prop_err = OVector::from_vec(vec![1.0, 2.0, 3.0]);
        let cur_state = OVector::from_vec(vec![1.0, 2.0, 3.0]);
        assert_eq!(rss_errors(&prop_err, &cur_state), 0.0);

        let prop_err = OVector::from_vec(vec![1.0, 2.0, 3.0]);
        let cur_state = OVector::from_vec(vec![4.0, 5.0, 6.0]);
        assert_eq!(rss_errors(&prop_err, &cur_state), 5.196152422706632);
    }
```

But I currently have some compiler complains about `from_vec`, so I gave up and trust the CI.

I hope to get feedback from you on this subject!