### PR TITLE
Add units to all state parameters

### DIFF
--- a/src/md/param.rs
+++ b/src/md/param.rs
@@ -304,7 +304,6 @@ impl FromStr for StateParameter {
     type Err = NyxError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let keyword = s
-            .trim()
             .split_whitespace()
             .next()
             .ok_or(NyxError::LoadingError(format!(


### PR DESCRIPTION
### Effects

Until this, state parameters did not include units. This fixes it. Eventually I might want to switch this to be in the base unit instead of the unit used in Nyx, because that would look better on the plots, but maybe that's something specific to plotting.

### If this change adds or modifies a validation case
- [x] No.
