### PR TITLE
Prevent parsing of covariance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ typed-builder = "0.14.0"
 polars = {version = "0.30.0", features = ["parquet"]}
 rstest = "0.18.1"
 pretty_env_logger = "0.5"
-easybench = "1.1.1"
 
 [build-dependencies]
 shadow-rs = "0.23.0"


### PR DESCRIPTION
### Effects
Prevents the OEM parser from crashing if it can't parse the line. Also prevents parsing the covariance data. This will be supported in #87 .
