### PR TITLE
Limit usage of std::Instant to non-wasm targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ dist/
 *.parquet
 *.profraw
 lcov.txt
-
+.DS_Store

--- a/src/cosmic/mod.rs
+++ b/src/cosmic/mod.rs
@@ -28,6 +28,7 @@ use hifitime::SECONDS_PER_DAY;
 use std::fmt;
 use std::fs::File;
 use std::io::Read;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 /// A trait allowing for something to have an epoch
@@ -180,10 +181,12 @@ impl Xb {
             return Err(NyxError::LoadingError("XB buffer is empty".to_string()));
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         let decode_start = Instant::now();
 
         match Self::decode(input_xb_buf) {
             Ok(xb) => {
+                #[cfg(not(target_arch = "wasm32"))]
                 debug!("Loaded XB in {} ms.", decode_start.elapsed().as_millis());
                 Ok(xb)
             }

--- a/src/mc/montecarlo.rs
+++ b/src/mc/montecarlo.rs
@@ -25,7 +25,9 @@ use crate::mc::DispersedState;
 use crate::md::trajectory::Interpolatable;
 use crate::md::EventEvaluator;
 use crate::propagators::{ErrorCtrl, Propagator};
-use crate::time::{Duration, Epoch, Unit};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::time::Unit;
+use crate::time::{Duration, Epoch};
 use crate::State;
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
 use rand_distr::Distribution;
@@ -34,6 +36,7 @@ use rayon::prelude::*;
 use std::f64;
 use std::fmt;
 use std::sync::mpsc::channel;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant as StdInstant;
 
 /// A Monte Carlo framework, automatically running on all threads via a thread pool. This framework is targeted toward analysis of time-continuous variables.
@@ -126,6 +129,7 @@ where
         let (tx, rx) = channel();
 
         // Generate all states (must be done separately because the rng is not thread safe)
+        #[cfg(not(target_arch = "wasm32"))]
         let start = StdInstant::now();
         init_states.par_iter().progress_with(pb).for_each_with(
             (prop, tx),
@@ -147,12 +151,15 @@ where
             },
         );
 
-        let clock_time = StdInstant::now() - start;
-        println!(
-            "Propagated {} states in {}",
-            num_runs,
-            clock_time.as_secs_f64() * Unit::Second
-        );
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let clock_time = StdInstant::now() - start;
+            println!(
+                "Propagated {} states in {}",
+                num_runs,
+                clock_time.as_secs_f64() * Unit::Second
+            );
+        }
 
         // Collect all of the results and sort them by run index
         let mut runs = rx
@@ -214,6 +221,7 @@ where
         let (tx, rx) = channel();
 
         // And propagate on the thread pool
+        #[cfg(not(target_arch = "wasm32"))]
         let start = StdInstant::now();
         init_states.par_iter().progress_with(pb).for_each_with(
             (prop, tx),
@@ -236,12 +244,15 @@ where
             },
         );
 
-        let clock_time = StdInstant::now() - start;
-        println!(
-            "Propagated {} states in {}",
-            num_runs,
-            clock_time.as_secs_f64() * Unit::Second
-        );
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let clock_time = StdInstant::now() - start;
+            println!(
+                "Propagated {} states in {}",
+                num_runs,
+                clock_time.as_secs_f64() * Unit::Second
+            );
+        }
 
         // Collect all of the results and sort them by run index
         let mut runs = rx.iter().collect::<Vec<Run<S, PropResult<S>>>>();

--- a/src/md/opti/raphson_finite_diff.rs
+++ b/src/md/opti/raphson_finite_diff.rs
@@ -29,6 +29,7 @@ use crate::propagators::error_ctrl::ErrorCtrl;
 use crate::pseudo_inverse;
 use hifitime::TimeUnits;
 use rayon::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
@@ -195,6 +196,7 @@ impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
 
         let width = f64::from(max_obj_val).log10() as usize + 2 + max_obj_tol;
 
+        #[cfg(not(target_arch = "wasm32"))]
         let start_instant = Instant::now();
 
         for it in 0..=self.iterations {
@@ -457,7 +459,10 @@ impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
             }
 
             if converged {
+                #[cfg(not(target_arch = "wasm32"))]
                 let conv_dur = Instant::now() - start_instant;
+                #[cfg(target_arch = "wasm32")]
+                let conv_dur = Duration::ZERO.into();
                 let mut corrected_state = xi_start;
 
                 let mut state_correction = Vector6::<f64>::zeros();

--- a/src/md/opti/raphson_hyperdual.rs
+++ b/src/md/opti/raphson_hyperdual.rs
@@ -25,6 +25,7 @@ pub use crate::md::{Variable, Vary};
 use crate::propagators::error_ctrl::ErrorCtrl;
 use crate::pseudo_inverse;
 use crate::utils::are_eigenvalues_stable;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
@@ -118,6 +119,7 @@ impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
 
         let width = f64::from(max_obj_val).log10() as usize + 2 + max_obj_tol;
 
+        #[cfg(not(target_arch = "wasm32"))]
         let start_instant = Instant::now();
 
         for it in 0..=self.iterations {
@@ -216,7 +218,10 @@ impl<'a, E: ErrorCtrl, const V: usize, const O: usize> Optimizer<'a, E, V, O> {
             }
 
             if converged {
+                #[cfg(not(target_arch = "wasm32"))]
                 let conv_dur = Instant::now() - start_instant;
+                #[cfg(target_arch = "wasm32")]
+                let conv_dur = Duration::ZERO.into();
                 let mut state = xi_start;
                 // Convert the total correction from VNC back to integration frame in case that's needed.
                 for (i, var) in self.variables.iter().enumerate() {

--- a/src/md/trajectory/orbit_traj.rs
+++ b/src/md/trajectory/orbit_traj.rs
@@ -32,6 +32,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 impl Traj<Orbit> {
@@ -44,6 +45,8 @@ impl Traj<Orbit> {
                 "No trajectory to convert".to_string(),
             )));
         }
+
+        #[cfg(not(target_arch = "wasm32"))]
         let start_instant = Instant::now();
         let mut traj = Self::new();
         for state in &self.states {
@@ -51,12 +54,21 @@ impl Traj<Orbit> {
         }
         traj.finalize();
 
+        #[cfg(not(target_arch = "wasm32"))]
         info!(
             "Converted trajectory from {} to {} in {} ms: {traj}",
             self.first().frame,
             new_frame,
             (Instant::now() - start_instant).as_millis()
         );
+
+        #[cfg(target_arch = "wasm32")]
+        info!(
+            "Converted trajectory from {} to {}: {traj}",
+            self.first().frame,
+            new_frame,
+        );
+
         Ok(traj)
     }
 

--- a/src/md/trajectory/sc_traj.rs
+++ b/src/md/trajectory/sc_traj.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 impl Traj<Spacecraft> {
@@ -38,6 +39,8 @@ impl Traj<Spacecraft> {
                 "No trajectory to convert".to_string(),
             )));
         }
+
+        #[cfg(not(target_arch = "wasm32"))]
         let start_instant = Instant::now();
         let mut traj = Self::new();
         for state in &self.states {
@@ -46,12 +49,21 @@ impl Traj<Spacecraft> {
         }
         traj.finalize();
 
+        #[cfg(not(target_arch = "wasm32"))]
         info!(
             "Converted trajectory from {} to {} in {} ms: {traj}",
             self.first().orbit.frame,
             new_frame,
             (Instant::now() - start_instant).as_millis()
         );
+
+        #[cfg(target_arch = "wasm32")]
+        info!(
+            "Converted trajectory from {} to {}: {traj}",
+            self.first().orbit.frame,
+            new_frame,
+        );
+
         Ok(traj)
     }
 


### PR DESCRIPTION
### Effects
All uses of `std::Instant` are now limited to targets other than `wasm32-*`. 
There should be no effect for targets other than WASM.

When targeting WebAssembly, it is now possible to use this library in environments where a time API is not available. For more details, see the original comment in #204 

### If this is a new feature or a bug fix ...
- [X] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [X] No.
- [ ] Yes and:
  - I have coded up, or updated, an existing test case; and
  - I have provided a GMAT script which confirms the result(s); and
  - I have updated the `VALIDATION.md` file with the new error data between nyx and GMAT.
  - I will specify the version of GMAT used for the validation.
