### PR TITLE
Export trajectory addition and frame conversion to Python

### DIFF
--- a/src/python/mission_design/orbit_trajectory.rs
+++ b/src/python/mission_design/orbit_trajectory.rs
@@ -167,6 +167,24 @@ impl OrbitTraj {
         }
     }
 
+    /// Allows converting the source trajectory into the (almost) equivalent trajectory in another frame.
+    /// This simply converts each state into the other frame and may lead to aliasing due to the Nyquist–Shannon sampling theorem.
+    fn to_frame(&self, new_frame: String) -> Result<Self, NyxError> {
+        let cosm = Cosm::de438();
+
+        let frame = cosm.try_frame(&new_frame)?;
+
+        let conv_traj = self.inner.to_frame(frame, cosm)?;
+
+        Ok(Self { inner: conv_traj })
+    }
+
+    fn __add__(&self, rhs: &Self) -> Result<Self, NyxError> {
+        let inner = (self.inner.clone() + rhs.inner.clone())?;
+
+        Ok(Self { inner })
+    }
+
     fn __str__(&self) -> String {
         format!("{}", self.inner)
     }

--- a/src/python/mission_design/sc_trajectory.rs
+++ b/src/python/mission_design/sc_trajectory.rs
@@ -172,6 +172,24 @@ impl SpacecraftTraj {
         }
     }
 
+    /// Allows converting the source trajectory into the (almost) equivalent trajectory in another frame.
+    /// This simply converts each state into the other frame and may lead to aliasing due to the Nyquist–Shannon sampling theorem.
+    fn to_frame(&self, new_frame: String) -> Result<Self, NyxError> {
+        let cosm = Cosm::de438();
+
+        let frame = cosm.try_frame(&new_frame)?;
+
+        let conv_traj = self.inner.to_frame(frame, cosm)?;
+
+        Ok(Self { inner: conv_traj })
+    }
+
+    fn __add__(&self, rhs: &Self) -> Result<Self, NyxError> {
+        let inner = (self.inner.clone() + rhs.inner.clone())?;
+
+        Ok(Self { inner })
+    }
+
     fn __str__(&self) -> String {
         format!("{}", self.inner)
     }


### PR DESCRIPTION
### Effects
Allows for this from Python:

```python
    traj1_moon = traj1.to_frame("Moon J2000")
    traj2_moon = traj2.to_frame("Moon J2000")

    traj_moon = traj1_moon + traj2_moon
```

This feature was already available in Rust.

#### Breaking changes

1. The addition operator in Rust now returns a Result type after checking for the frame. Prior to this PR, it was possible to add two trajectories in different frames.
2. The order of addition matters: with `self+rhs`, only the states whose epoch is greater than `self.last().epoch` are added to the trajectory, so if there is an overlap in epochs, the order of the addition matters.

### If this is a new feature or a bug fix ...
- [x] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [x] No.
