### PR TITLE
Support pickling of a number of important structures to Python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,7 @@ jobs:
           set -e
           ls -lh dist
           pip install nyx_space --find-links dist --force-reinstall -v --no-cache-dir
-          pip install pytest numpy pandas plotly pyarrow scipy
+          pip install pytest numpy pandas plotly pyarrow scipy pyyaml
           pytest
 
       - name: Upload python tests HTMLs
@@ -82,7 +82,7 @@ jobs:
           set -e
           ls -lh dist
           pip install --find-links dist --force-reinstall nyx_space
-          pip install pytest numpy pandas plotly pyarrow
+          pip install pytest numpy pandas plotly pyarrow pyyaml
           pytest
 
   macos:
@@ -115,7 +115,7 @@ jobs:
           set -e
           ls -lh dist
           pip install --find-links dist --force-reinstall nyx_space
-          pip install pytest numpy pandas plotly pyarrow
+          pip install pytest numpy pandas plotly pyarrow pyyaml
           pytest
 
   sdist:

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ node_modules/
 *.svg
 *.data
 *.folded
-*.venv
+*.venv*
 dist/
 *.parquet
 *.profraw

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ typed-builder = "0.15.0"
 pythonize = { version = "0.19", optional = true }
 
 [dev-dependencies]
-polars = { version = "0.31.1", features = ["parquet"] }
+polars = { version = "0.32.1", features = ["parquet"] }
 rstest = "0.18.1"
 pretty_env_logger = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,21 @@ keywords = ["space", "mission", "design", "orbit", "estimation"]
 categories = ["science", "simulation", "aerospace", "science::robotics"]
 readme = "README.md"
 license = "AGPL-3.0-or-later"
-exclude = ["tests/GMAT_scripts/*", "examples", "data/*.gz", "data/*.png", "data/od_plots/", "rustfmt.toml", "de438s.xb", "Pipfile*", ".vscode/launch.json", "*.kst", "docs/*", "*.bsp", "data/tests/*"]
+exclude = [
+    "tests/GMAT_scripts/*",
+    "examples",
+    "data/*.gz",
+    "data/*.png",
+    "data/od_plots/",
+    "rustfmt.toml",
+    "de438s.xb",
+    "Pipfile*",
+    ".vscode/launch.json",
+    "*.kst",
+    "docs/*",
+    "*.bsp",
+    "data/tests/*",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -21,8 +35,10 @@ gitlab = { repository = "nyx-space/nyx", branch = "master" }
 [dependencies]
 nalgebra = "=0.32"
 log = "0.4"
-hifitime = { version = "3.8.2", features = ["std"] }
-flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
+hifitime = { version = "3.8.3", features = ["std"] }
+flate2 = { version = "1.0", features = [
+    "rust_backend",
+], default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 csv = "1"
@@ -40,26 +56,29 @@ rayon = "1.6"
 lazy_static = "1.4.0"
 approx = "0.5"
 rand_pcg = "0.3"
-pyo3 = {version = "0.18.0", optional = true, features = ["extension-module"]}
-pyo3-log = {version = "0.8.2", optional = true}
-numpy = {version = "0.18", optional = true}
-indicatif = {version = "0.17", features = ["rayon"]}
+pyo3 = { version = "0.19.0", optional = true, features = ["extension-module"] }
+pyo3-log = { version = "0.8.2", optional = true }
+numpy = { version = "0.19", optional = true }
+indicatif = { version = "0.17", features = ["rayon"] }
 rstats = "1.2.50"
 thiserror = "1.0"
-parquet = {version = "45.0.0", default-features = false, features = ["arrow", "brotli"]}
+parquet = { version = "45.0.0", default-features = false, features = [
+    "arrow",
+    "brotli",
+] }
 arrow = "45.0.0"
-shadow-rs = {version = "0.23.0", default-features = false}
+shadow-rs = { version = "0.23.0", default-features = false }
 serde_yaml = "0.9.21"
 whoami = "1.3.0"
-either = {version = "1.8.1", features = ["serde"]}
+either = { version = "1.8.1", features = ["serde"] }
 num = "0.4.0"
 enum-iterator = "1.4.0"
-getrandom = {version = "0.2", features = ["js"]}
+getrandom = { version = "0.2", features = ["js"] }
 typed-builder = "0.15.0"
-pythonize = "0.18"
+pythonize = { version = "0.19", optional = true }
 
 [dev-dependencies]
-polars = {version = "0.31.1", features = ["parquet"]}
+polars = { version = "0.31.1", features = ["parquet"] }
 rstest = "0.18.1"
 pretty_env_logger = "0.5"
 
@@ -68,7 +87,7 @@ shadow-rs = "0.23.0"
 
 [features]
 default = []
-python = ["pyo3", "pyo3-log", "hifitime/python", "numpy"]
+python = ["pyo3", "pyo3-log", "hifitime/python", "numpy", "pythonize"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ num = "0.4.0"
 enum-iterator = "1.4.0"
 getrandom = {version = "0.2", features = ["js"]}
 typed-builder = "0.15.0"
+pythonize = "0.18"
 
 [dev-dependencies]
 polars = {version = "0.31.1", features = ["parquet"]}

--- a/python/nyx_space/plots/utils.py
+++ b/python/nyx_space/plots/utils.py
@@ -23,13 +23,13 @@ import numpy as np
 # Color blindness friendly colors, from https://jfly.uni-koeln.de/color/#pallet
 # And from https://davidmathlogic.com/colorblind/#%23E1BE6A-%2340B0A6-%237bcb12-%233d9087
 colors = {
-    "orange": (230, 159, 0),  # #e69f00
     "sky_blue": (86, 180, 233),  # #56b4e9
-    "green": (0, 158, 115),  # #009e73
-    "yellow": (240, 228, 66),  # #f0e442
-    "blue": (0, 114, 178),  # #0072b2
-    "red_ish": (213, 94, 0),  # #d55e00
     "purple": (204, 121, 167),  # #cc79a7
+    "green": (0, 158, 115),  # #009e73
+    "red_ish": (213, 94, 0),  # #d55e00
+    "orange": (230, 159, 0),  # #e69f00
+    "blue": (0, 114, 178),  # #0072b2
+    "yellow": (240, 228, 66),  # #f0e442
     "yellow2": (255, 194, 10),  # #ffc20a
     "blue2": (12, 123, 220),  # #0c7bdc
     "bright_green": (26, 255, 26),  # #1aff1a

--- a/src/cosmic/orbit.rs
+++ b/src/cosmic/orbit.rs
@@ -48,6 +48,8 @@ use crate::io::ConfigError;
 #[cfg(feature = "python")]
 use crate::python::cosmic::Frame as PyFrame;
 #[cfg(feature = "python")]
+use pyo3::class::basic::CompareOp;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
 use pyo3::types::PyType;
@@ -1591,8 +1593,12 @@ impl Orbit {
     }
 
     #[cfg(feature = "python")]
-    fn __eq__(&self, other: &Self) -> bool {
-        self == other
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> Result<bool, NyxError> {
+        match op {
+            CompareOp::Eq => Ok(self == other),
+            CompareOp::Ne => Ok(self != other),
+            _ => Err(NyxError::CustomError(format!("{op:?} not available"))),
+        }
     }
 
     /// Creates a new Orbit in the provided frame at the provided Epoch given the position and velocity components.

--- a/src/cosmic/orbit.rs
+++ b/src/cosmic/orbit.rs
@@ -1323,7 +1323,11 @@ impl Orbit {
                         .to_degrees(),
                     )
                 } else if self.ecc() > 1.0 {
-                    info!("computing the hyperbolic anomaly");
+                    info!(
+                        "computing the hyperbolic anomaly (ecc = {:.6} @ {})",
+                        self.ecc(),
+                        self.epoch
+                    );
                     // From GMAT's TrueToHyperbolicAnomaly
                     ((self.ta_deg().to_radians().sin() * (self.ecc().powi(2) - 1.0)).sqrt()
                         / (1.0 + self.ecc() * self.ta_deg().to_radians().cos()))

--- a/src/cosmic/spacecraft.rs
+++ b/src/cosmic/spacecraft.rs
@@ -82,6 +82,7 @@ impl From<GuidanceMode> for f64 {
 /// Optionally, the spacecraft state can also store the state transition matrix from the start of the propagation until the current time (i.e. trajectory STM, not step-size STM).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.cosmic"))]
 #[cfg_attr(
     feature = "python",
     pyo3(
@@ -127,6 +128,7 @@ impl Default for Spacecraft {
 
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(text_signature = "(area_m2, cr=1.8)"))]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.cosmic"))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// The Solar Radiation Pressure configuration for a spacecraft
 pub struct SrpConfig {
@@ -157,6 +159,7 @@ impl Default for SrpConfig {
 
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(text_signature = "(area_m2, cd=2.2)"))]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.cosmic"))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// The drag configuration for a spacecraft
 pub struct DragConfig {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -218,7 +218,7 @@ pub trait ConfigRepr: Debug + Sized + Serialize + DeserializeOwned {
         serde_yaml::from_reader(reader).map_err(ConfigError::ParseError)
     }
 
-    // Builds a sequence of "Selves" from the provided string of a yaml
+    /// Builds a sequence of "Selves" from the provided string of a yaml
     fn loads_many(data: &str) -> Result<Vec<Self>, ConfigError> {
         debug!("Loading YAML:\n{data}");
         serde_yaml::from_str(data).map_err(ConfigError::ParseError)

--- a/src/io/trajectory_data.rs
+++ b/src/io/trajectory_data.rs
@@ -35,6 +35,8 @@ use crate::Spacecraft;
 #[cfg(feature = "python")]
 use log::warn;
 #[cfg(feature = "python")]
+use pyo3::class::basic::CompareOp;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 use crate::cosmic::Cosm;
@@ -345,7 +347,12 @@ impl TrajectoryLoader {
         Ok((self.path.clone(),))
     }
 
-    fn __eq__(&self, other: &Self) -> bool {
-        self == other
+    #[cfg(feature = "python")]
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> Result<bool, NyxError> {
+        match op {
+            CompareOp::Eq => Ok(self == other),
+            CompareOp::Ne => Ok(self != other),
+            _ => Err(NyxError::CustomError(format!("{op:?} not available"))),
+        }
     }
 }

--- a/src/md/trajectory/traj.rs
+++ b/src/md/trajectory/traj.rs
@@ -531,7 +531,12 @@ where
             }
         }
 
-        info!("Serialized {} states", states.len());
+        info!(
+            "Serialized {} states from {} to {}",
+            states.len(),
+            states.first().unwrap().epoch(),
+            states.last().unwrap().epoch()
+        );
 
         // Add all of the evaluated events
         if let Some(events) = events {

--- a/src/od/ground_station.rs
+++ b/src/od/ground_station.rs
@@ -37,6 +37,7 @@ use pyo3::prelude::*;
 /// GroundStation defines a two-way ranging and doppler station.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.orbit_determination"))]
 pub struct GroundStation {
     pub name: String,
     /// in degrees

--- a/src/od/noise/gauss_markov.rs
+++ b/src/od/noise/gauss_markov.rs
@@ -455,7 +455,7 @@ impl GaussMarkov {
     }
 
     #[cfg(feature = "python")]
-    /// Tries to load a GroundStation from the provided Python data
+    /// Loads the SpacecraftDynamics from its YAML representation
     #[classmethod]
     fn loads(_cls: &PyType, data: &PyAny) -> Result<Vec<Self>, ConfigError> {
         if let Ok(as_list) = data.downcast::<PyList>() {

--- a/src/od/noise/gauss_markov.rs
+++ b/src/od/noise/gauss_markov.rs
@@ -366,12 +366,12 @@ impl GaussMarkov {
         bias: Option<f64>,
         epoch: Option<Epoch>,
     ) -> Result<Self, ConfigError> {
-        if tau.is_none() && sigma.is_none() && bias.is_none() {
+        if tau.is_none() && sigma.is_none() && steady_state.is_none() {
             // We're called from pickle, return a non initialized state
             return Ok(Self::ZERO);
-        } else if tau.is_none() || sigma.is_none() || bias.is_none() {
+        } else if tau.is_none() || sigma.is_none() || steady_state.is_none() {
             return Err(ConfigError::InvalidConfig(format!(
-                "tau, sigma, and bias must be specified"
+                "tau, sigma, and steady_state must be specified"
             )));
         }
 

--- a/src/od/process/rejectcrit.rs
+++ b/src/od/process/rejectcrit.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 /// If unsure, use the default: `FltResid::default()` in Rust, and `FltResid()` in Python (i.e. construct without arguments).
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
-#[cfg_attr(feature = "python", pyo3(module = "nyx_space.mission_design"))]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.orbit_determination"))]
 #[cfg_attr(
     feature = "python",
     pyo3(text_signature = "(min_accepted=None, num_sigmas=None)")

--- a/src/od/process/rejectcrit.rs
+++ b/src/od/process/rejectcrit.rs
@@ -19,14 +19,21 @@
 use crate::cosmic::Cosm;
 use crate::io::{ConfigError, ConfigRepr, Configurable};
 #[cfg(feature = "python")]
+use crate::NyxError;
+#[cfg(feature = "python")]
+use pyo3::class::basic::CompareOp;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pythonize::{depythonize, pythonize};
 use serde_derive::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Reject measurements with a residual ratio greater than the provided sigmas values. Will only be turned used if at least min_accepted measurements have been processed so far.
 /// If unsure, use the default: `FltResid::default()` in Rust, and `FltResid()` in Python (i.e. construct without arguments).
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.mission_design"))]
 #[cfg_attr(
     feature = "python",
     pyo3(text_signature = "(min_accepted=None, num_sigmas=None)")
@@ -81,6 +88,27 @@ impl FltResid {
 
     fn __str__(&self) -> String {
         format!("{self:?}")
+    }
+
+    fn dumps(&self, py: Python) -> Result<PyObject, NyxError> {
+        pythonize(py, &self).map_err(|e| NyxError::CustomError(e.to_string()))
+    }
+
+    fn __getstate__(&self, py: Python) -> Result<PyObject, NyxError> {
+        self.dumps(py)
+    }
+
+    fn __setstate__(&mut self, state: &PyAny) -> Result<(), ConfigError> {
+        *self = depythonize(state).map_err(|e| ConfigError::InvalidConfig(e.to_string()))?;
+        Ok(())
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> Result<bool, NyxError> {
+        match op {
+            CompareOp::Eq => Ok(self == other),
+            CompareOp::Ne => Ok(self != other),
+            _ => Err(NyxError::CustomError(format!("{op:?} not available"))),
+        }
     }
 }
 

--- a/src/od/simulator/arc.rs
+++ b/src/od/simulator/arc.rs
@@ -168,6 +168,7 @@ where
             prev: Option<Epoch>,
             end: Option<Epoch>,
         }
+
         let mut schedule: HashMap<String, ScheduleData> = HashMap::new();
 
         let mut start_trace_msg = HashSet::new();

--- a/src/od/simulator/trkconfig.rs
+++ b/src/od/simulator/trkconfig.rs
@@ -37,6 +37,7 @@ use super::Availability;
 /// In Python, any value that is set to None at initialization will use the default values.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(feature = "python", pyo3(module = "nyx_space.orbit_determination"))]
 #[cfg_attr(
     feature = "python",
     pyo3(

--- a/src/python/mission_design/spacecraft.rs
+++ b/src/python/mission_design/spacecraft.rs
@@ -103,6 +103,12 @@ impl Spacecraft {
         self.dumps(py)
     }
 
+    #[classmethod]
+    /// Loads the SpacecraftDynamics from its YAML representation
+    fn loads(_cls: &PyType, state: &PyAny) -> Result<Self, ConfigError> {
+        depythonize(state).map_err(|e| ConfigError::InvalidConfig(e.to_string()))
+    }
+
     fn __setstate__(&mut self, state: &PyAny) -> Result<(), ConfigError> {
         *self = depythonize(state).map_err(|e| ConfigError::InvalidConfig(e.to_string()))?;
         Ok(())

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod cosmic;
 pub(crate) mod mission_design;
 mod monte_carlo;
 mod orbit_determination;
+pub(crate) mod pyo3utils;
 
 impl From<NyxError> for PyErr {
     fn from(err: NyxError) -> PyErr {

--- a/src/python/orbit_determination/arc.rs
+++ b/src/python/orbit_determination/arc.rs
@@ -1,0 +1,81 @@
+/*
+    Nyx, blazing fast astrodynamics
+    Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use std::collections::HashMap;
+
+use crate::cosmic::Cosm;
+use crate::io::trajectory_data::TrajectoryLoader;
+use crate::io::ExportCfg;
+use crate::od::msr::RangeDoppler;
+use crate::od::simulator::TrackingArcSim;
+pub use crate::od::simulator::TrkConfig;
+pub use crate::{io::ConfigError, od::prelude::GroundStation};
+use crate::{NyxError, Spacecraft};
+use pyo3::prelude::*;
+
+#[derive(Clone)]
+#[pyclass]
+pub struct GroundTrackingArcSim {
+    inner: TrackingArcSim<Spacecraft, RangeDoppler, GroundStation>,
+}
+
+#[pymethods]
+impl GroundTrackingArcSim {
+    /// Initializes a new tracking arc simulation from the provided devices, trajectory, and the random number generator seed.
+    #[new]
+    pub fn with_seed(
+        devices: Vec<GroundStation>,
+        trajectory: TrajectoryLoader,
+        configs: HashMap<String, TrkConfig>,
+        seed: u64,
+    ) -> Result<Self, NyxError> {
+        // Try to convert the dynamic trajectory into an Orbit trajectory
+        let traj = trajectory
+            .to_traj()
+            .map_err(|e| NyxError::CustomError(e.to_string()))?;
+
+        let inner = TrackingArcSim::with_seed(devices, traj, configs, seed)
+            .map_err(NyxError::ConfigError)?;
+
+        Ok(Self { inner })
+    }
+
+    /// Generates simulated measurements and returns the path where the parquet file containing said measurements is stored.
+    /// You may specify a metadata dictionary to be stored in the parquet file and whether the filename should include the timestamp.
+    #[pyo3(text_signature = "(path, metadata=None, timestamp=False)")]
+    pub fn generate_measurements(
+        &mut self,
+        path: String,
+        export_cfg: ExportCfg,
+    ) -> Result<String, NyxError> {
+        let cosm = Cosm::de438();
+        let arc = self.inner.generate_measurements(cosm)?;
+
+        // Save the tracking arc
+        let maybe = arc.to_parquet(path, export_cfg);
+
+        match maybe {
+            Ok(path) => Ok(format!("{}", path.to_str().unwrap())),
+            Err(e) => Err(NyxError::CustomError(e.to_string())),
+        }
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("{}", self.inner)
+    }
+}

--- a/src/python/orbit_determination/ground_station.rs
+++ b/src/python/orbit_determination/ground_station.rs
@@ -115,8 +115,8 @@ impl GroundStation {
         <Self as ConfigRepr>::load_named(path)
     }
 
-    /// Tries to load a GroundStation from the provided Python data
     #[classmethod]
+    /// Loads the SpacecraftDynamics from its YAML representation
     fn loads(_cls: &PyType, data: &PyAny) -> Result<HashMap<String, Self>, ConfigError> {
         if let Ok(as_list) = data.downcast::<PyList>() {
             let mut as_map = HashMap::new();

--- a/src/python/orbit_determination/ground_station.rs
+++ b/src/python/orbit_determination/ground_station.rs
@@ -22,8 +22,9 @@ use crate::cosmic::{Cosm, Orbit};
 use crate::io::ConfigRepr;
 use crate::od::simulator::TrackingDeviceSim;
 pub use crate::od::simulator::TrkConfig;
+use crate::time::Duration;
 use crate::NyxError;
-pub use crate::{io::ConfigError, od::prelude::GroundStation};
+pub use crate::{io::ConfigError, od::noise::GaussMarkov, od::prelude::GroundStation};
 
 use crate::python::cosmic::Cosm as CosmPy;
 use crate::python::pyo3utils::pyany_to_value;
@@ -33,7 +34,70 @@ use pyo3::types::{PyDict, PyList, PyType};
 
 #[pymethods]
 impl GroundStation {
-    #[cfg(feature = "python")]
+    #[new]
+    fn new(
+        name: String,
+        elevation_mask_deg: f64,
+        latitude_deg: f64,
+        longitude_deg: f64,
+        height_km: f64,
+        frame_name: String,
+        light_time_correction: bool,
+        integration_time: Option<Duration>,
+        timestamp_noise_s: Option<GaussMarkov>,
+        range_noise_km: Option<GaussMarkov>,
+        doppler_noise_km_s: Option<GaussMarkov>,
+    ) -> Result<Self, NyxError> {
+        let cosm = Cosm::de438();
+        let frame = cosm.try_frame(&frame_name)?;
+        Ok(Self {
+            name,
+            elevation_mask_deg,
+            latitude_deg,
+            longitude_deg,
+            height_km,
+            frame,
+            integration_time,
+            light_time_correction,
+            timestamp_noise_s,
+            range_noise_km,
+            doppler_noise_km_s,
+        })
+    }
+
+    fn __getnewargs__(
+        &self,
+    ) -> Result<
+        (
+            String,
+            f64,
+            f64,
+            f64,
+            f64,
+            String,
+            bool,
+            Option<Duration>,
+            Option<GaussMarkov>,
+            Option<GaussMarkov>,
+            Option<GaussMarkov>,
+        ),
+        NyxError,
+    > {
+        Ok((
+            self.name.clone(),
+            self.elevation_mask_deg,
+            self.latitude_deg,
+            self.longitude_deg,
+            self.height_km,
+            self.frame.to_string(),
+            self.light_time_correction,
+            self.integration_time,
+            self.timestamp_noise_s,
+            self.range_noise_km,
+            self.doppler_noise_km_s,
+        ))
+    }
+
     #[classmethod]
     fn load(_cls: &PyType, path: &str) -> Result<Self, ConfigError> {
         <Self as ConfigRepr>::load(path)
@@ -50,6 +114,8 @@ impl GroundStation {
     }
 
     /// Tries to load a GroundStation from the provided Python data
+    /// TODO: Load from dict directly
+    /// TODO: Pickle via ConfigRepr, probably need a Dumps function
     #[classmethod]
     fn loads(_cls: &PyType, data: &PyAny) -> Result<HashMap<String, Self>, ConfigError> {
         if let Ok(as_list) = data.downcast::<PyList>() {
@@ -59,6 +125,33 @@ impl GroundStation {
                 let next: Self = serde_yaml::from_value(pyany_to_value(item)?)
                     .map_err(ConfigError::ParseError)?;
                 as_map.insert(next.name.clone(), next);
+            }
+            Ok(as_map)
+        } else if let Ok(as_dict) = data.downcast::<PyDict>() {
+            let mut as_map = HashMap::new();
+            for item_as_list in as_dict.items() {
+                let k_any = item_as_list.get_item(0).or_else(|_| {
+                    Err(ConfigError::InvalidConfig(
+                        "could not get key from provided dictionary item".to_string(),
+                    ))
+                })?;
+                let v_any = item_as_list.get_item(1).or_else(|_| {
+                    Err(ConfigError::InvalidConfig(
+                        "could not get key from provided dictionary item".to_string(),
+                    ))
+                })?;
+                // Check that it's a string, or abort here
+                if let Ok(as_str) = k_any.extract::<String>() {
+                    // Try to convert the underlying data
+                    let next: Self = serde_yaml::from_value(pyany_to_value(v_any)?)
+                        .map_err(ConfigError::ParseError)?;
+                    as_map.insert(as_str, next);
+                } else {
+                    return Err(ConfigError::InvalidConfig(
+                        "keys for `loads` must be strings, otherwise, use GroundStation(**data)"
+                            .to_string(),
+                    ));
+                }
             }
             Ok(as_map)
         } else {

--- a/src/python/orbit_determination/mod.rs
+++ b/src/python/orbit_determination/mod.rs
@@ -16,20 +16,14 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-use std::collections::HashMap;
-
-use crate::cosmic::Cosm;
 use crate::io::tracking_data::DynamicTrackingArc;
-use crate::io::trajectory_data::TrajectoryLoader;
 use crate::io::ExportCfg;
-use crate::od::msr::RangeDoppler;
 use crate::od::noise::GaussMarkov;
 use crate::od::process::FltResid;
-use crate::od::simulator::TrackingArcSim;
 pub use crate::od::simulator::TrkConfig;
 pub use crate::{io::ConfigError, od::prelude::GroundStation};
-use crate::{NyxError, Spacecraft};
 use pyo3::{prelude::*, py_run};
+mod arc;
 pub(crate) mod estimate;
 mod ground_station;
 mod process;
@@ -42,7 +36,7 @@ pub(crate) fn register_od(py: Python<'_>, parent_module: &PyModule) -> PyResult<
     let sm = PyModule::new(py, "_nyx_space.orbit_determination")?;
 
     sm.add_class::<GroundStation>()?;
-    sm.add_class::<GroundTrackingArcSim>()?;
+    sm.add_class::<arc::GroundTrackingArcSim>()?;
     sm.add_class::<DynamicTrackingArc>()?;
     sm.add_class::<TrkConfig>()?;
     sm.add_class::<OrbitEstimate>()?;
@@ -59,56 +53,4 @@ pub(crate) fn register_od(py: Python<'_>, parent_module: &PyModule) -> PyResult<
     );
     parent_module.add_submodule(sm)?;
     Ok(())
-}
-
-#[derive(Clone)]
-#[pyclass]
-pub struct GroundTrackingArcSim {
-    inner: TrackingArcSim<Spacecraft, RangeDoppler, GroundStation>,
-}
-
-#[pymethods]
-impl GroundTrackingArcSim {
-    /// Initializes a new tracking arc simulation from the provided devices, trajectory, and the random number generator seed.
-    #[new]
-    pub fn with_seed(
-        devices: Vec<GroundStation>,
-        trajectory: TrajectoryLoader,
-        configs: HashMap<String, TrkConfig>,
-        seed: u64,
-    ) -> Result<Self, NyxError> {
-        // Try to convert the dynamic trajectory into an Orbit trajectory
-        let traj = trajectory
-            .to_traj()
-            .map_err(|e| NyxError::CustomError(e.to_string()))?;
-
-        let inner = TrackingArcSim::with_seed(devices, traj, configs, seed)
-            .map_err(NyxError::ConfigError)?;
-
-        Ok(Self { inner })
-    }
-
-    /// Generates simulated measurements and returns the path where the parquet file containing said measurements is stored.
-    /// You may specify a metadata dictionary to be stored in the parquet file and whether the filename should include the timestamp.
-    #[pyo3(text_signature = "(path, metadata=None, timestamp=False)")]
-    pub fn generate_measurements(
-        &mut self,
-        path: String,
-        export_cfg: ExportCfg,
-    ) -> Result<String, NyxError> {
-        let cosm = Cosm::de438();
-        let arc = self.inner.generate_measurements(cosm)?;
-
-        // Save the tracking arc
-        let maybe = arc.to_parquet(path, export_cfg);
-
-        match maybe {
-            Ok(path) => Ok(format!("{}", path.to_str().unwrap())),
-            Err(e) => Err(NyxError::CustomError(e.to_string())),
-        }
-    }
-
-    pub fn __repr__(&self) -> String {
-        format!("{}", self.inner)
-    }
 }

--- a/src/python/orbit_determination/trkconfig.rs
+++ b/src/python/orbit_determination/trkconfig.rs
@@ -19,8 +19,10 @@ pub use crate::io::ConfigError;
 pub use crate::od::simulator::{Schedule, TrkConfig};
 use crate::{io::ConfigRepr, od::simulator::Availability, NyxError};
 use hifitime::{Duration, Epoch};
+use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
+use pythonize::{depythonize, pythonize};
 use std::{collections::HashMap, str::FromStr};
 
 #[pymethods]
@@ -100,6 +102,27 @@ impl TrkConfig {
 
     fn __str__(&self) -> String {
         format!("{self:?}")
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> Result<bool, NyxError> {
+        match op {
+            CompareOp::Eq => Ok(self == other),
+            CompareOp::Ne => Ok(self != other),
+            _ => Err(NyxError::CustomError(format!("{op:?} not available"))),
+        }
+    }
+
+    fn dumps(&self, py: Python) -> Result<PyObject, NyxError> {
+        pythonize(py, &self).map_err(|e| NyxError::CustomError(e.to_string()))
+    }
+
+    fn __getstate__(&self, py: Python) -> Result<PyObject, NyxError> {
+        self.dumps(py)
+    }
+
+    fn __setstate__(&mut self, state: &PyAny) -> Result<(), ConfigError> {
+        *self = depythonize(state).map_err(|e| ConfigError::InvalidConfig(e.to_string()))?;
+        Ok(())
     }
 
     #[getter]

--- a/src/python/orbit_determination/trkconfig.rs
+++ b/src/python/orbit_determination/trkconfig.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, str::FromStr};
-
 /*
     Nyx, blazing fast astrodynamics
     Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com>
@@ -23,6 +21,7 @@ use crate::{io::ConfigRepr, od::simulator::Availability, NyxError};
 use hifitime::{Duration, Epoch};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
+use std::{collections::HashMap, str::FromStr};
 
 #[pymethods]
 impl TrkConfig {

--- a/src/python/pyo3utils/mod.rs
+++ b/src/python/pyo3utils/mod.rs
@@ -1,0 +1,63 @@
+/*
+    Nyx, blazing fast astrodynamics
+    Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use crate::io::ConfigError;
+use pyo3::types::{PyAny, PyDict, PyList};
+use serde_yaml::{Mapping, Value};
+
+/// Try to convert the provided PyAny into a SerDe YAML Value
+pub fn pyany_to_value(any: &PyAny) -> Result<Value, ConfigError> {
+    if let Ok(as_bool) = any.extract::<bool>() {
+        Ok(Value::Bool(as_bool))
+    } else if let Ok(as_str) = any.extract::<String>() {
+        Ok(Value::String(as_str))
+    } else if let Ok(as_f64) = any.extract::<f64>() {
+        Ok(Value::Number(as_f64.into()))
+    } else if let Ok(as_int) = any.extract::<i64>() {
+        Ok(Value::Number(as_int.into()))
+    } else if let Ok(as_int) = any.extract::<i32>() {
+        Ok(Value::Number(as_int.into()))
+    } else if let Ok(as_list) = any.downcast::<PyList>() {
+        let mut seq = Vec::new();
+        for item in as_list.iter() {
+            seq.push(pyany_to_value(item)?);
+        }
+        Ok(Value::Sequence(seq))
+    } else if let Ok(as_dict) = any.downcast::<PyDict>() {
+        let mut map = Mapping::new();
+        for item_as_list in as_dict.items() {
+            let k = pyany_to_value(item_as_list.get_item(0).or_else(|_| {
+                Err(ConfigError::InvalidConfig(
+                    "could not get key from provided dictionary item".to_string(),
+                ))
+            })?)?;
+            let v = pyany_to_value(item_as_list.get_item(1).or_else(|_| {
+                Err(ConfigError::InvalidConfig(
+                    "could not get value from provided dictionary item".to_string(),
+                ))
+            })?)?;
+            map.insert(k, v);
+        }
+
+        Ok(Value::Mapping(map))
+    } else {
+        Err(ConfigError::InvalidConfig(
+            "cannot convert input (not one of bool, int, float, str, List, Dict)".to_string(),
+        ))
+    }
+}

--- a/tests/python/test_cosmic.py
+++ b/tests/python/test_cosmic.py
@@ -79,6 +79,8 @@ def test_define_spacecraft():
     # Check that we can pickle and dump the config of this spacecraft
     pkld = pickle.dumps(sc)
     print(sc.dumps())
+    sc_loaded = Spacecraft.loads(sc.dumps())
+    assert sc_loaded == sc
     unpkld = pickle.loads(pkld)
     assert unpkld == sc
 

--- a/tests/python/test_cosmic.py
+++ b/tests/python/test_cosmic.py
@@ -1,6 +1,7 @@
 from nyx_space.cosmic import Cosm, Orbit, Spacecraft, SrpConfig, DragConfig
 from nyx_space.time import Epoch, Unit, Duration
 from nyx_space.monte_carlo import generate_orbits, generate_spacecraft, StateParameter
+import pickle
 
 
 def test_load_cosm():
@@ -75,9 +76,15 @@ def test_define_spacecraft():
 
     print(sc.orbit)
 
+    # Check that we can pickle and dump the config of this spacecraft
+    pkld = pickle.dumps(sc)
+    print(sc.dumps())
+    unpkld = pickle.loads(pkld)
+    assert unpkld == sc
+
     # NOTE: This does not return a pointer to the object, but a new object!
     # Therefore the equality _will_ fail!
-    assert orbit != sc.orbit
+    assert orbit == sc.orbit
     # But the printed information is identical
     assert f"{orbit}" == f"{sc.orbit}"
     # And the epochs match
@@ -152,3 +159,7 @@ def test_generate_states():
         seed=42,
     )
     assert len(spacecraft) == 100
+
+
+if __name__ == "__main__":
+    test_define_spacecraft()

--- a/tests/python/test_mission_design.py
+++ b/tests/python/test_mission_design.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from timeit import timeit
 
 import pandas as pd
+import yaml
 from nyx_space.cosmic import Cosm, Orbit, Spacecraft, SrpConfig
 from nyx_space.mission_design import (
     Event,
@@ -283,6 +284,13 @@ def test_merge_traj():
         str(config_path.joinpath("dynamics.yaml"))
     )["lofi"]
 
+    # Check loading from the YAML read from Python
+    with open(config_path.joinpath("dynamics.yaml")) as fh:
+        data = yaml.safe_load(fh)
+
+    loaded = SpacecraftDynamics.loads(data["lofi"])
+    assert loaded == dynamics
+
     sc2, traj1 = propagate(sc1, dynamics, Unit.Day * 5)
     # And propagate again
     sc3, traj2 = propagate(sc2, dynamics, Unit.Day * 5)
@@ -303,4 +311,5 @@ def test_merge_traj():
 
 
 if __name__ == "__main__":
-    test_propagate()
+    # test_propagate()
+    test_merge_traj()

--- a/tests/python/test_mission_design.py
+++ b/tests/python/test_mission_design.py
@@ -174,7 +174,7 @@ def test_build_spacecraft():
     sc = Spacecraft(orbit, 150.0, 15.0, srp)
     print(sc)
 
-    assert sc.srp().__eq__(srp)  # Not sure why the `==` operator doesn't work here
+    assert sc.srp() == srp
     assert sc.drag().area_m2 == 0.0
     assert (
         sc.drag().cd == 2.2
@@ -192,7 +192,7 @@ def test_build_spacecraft():
     # Check that we can pickle the trajectory loader object
     traj_pkl = pickle.dumps(traj)
     traj_unpkl = pickle.loads(traj_pkl)
-    assert traj_unpkl.__eq__(traj)
+    assert traj_unpkl == traj
     # Check that we can convert this to a spacecraft trajectory
     traj_sc = traj.to_spacecraft_traj()
     traj_orbit = traj.to_orbit_traj()
@@ -215,7 +215,7 @@ def test_build_spacecraft():
         # Check the downcasted version
         assert dc_orbit.x_km == sc_orbit.x_km
         assert dc_orbit.vx_km_s == sc_orbit.vx_km_s
-        assert dc_orbit.__eq__(sc_orbit)
+        assert dc_orbit == sc_orbit
 
 
 def test_two_body():

--- a/tests/python/test_orbit_determination.py
+++ b/tests/python/test_orbit_determination.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import pickle
 import numpy as np
 import pandas as pd
 import sys
@@ -70,6 +71,11 @@ def test_filter_arc():
 
     # Load the tracking configuration as a dictionary
     trk_cfg = TrkConfig.load_named(str(config_path.joinpath("tracking_cfg.yaml")))
+    # Check that we can pickle and compare
+    trk_cfg_demo = trk_cfg["Demo ground station"]
+    print(trk_cfg_demo.dumps())
+    unpkld = pickle.loads(pickle.dumps(trk_cfg_demo))
+    assert unpkld == trk_cfg_demo
 
     # Load the trajectory
     traj = TrajectoryLoader(traj_file)

--- a/tests/python/test_orbit_determination.py
+++ b/tests/python/test_orbit_determination.py
@@ -1,31 +1,32 @@
 import logging
-from pathlib import Path
 import pickle
+import sys
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-import sys
-
+import yaml
+from nyx_space.analysis import diff_traj_parquet
+from nyx_space.cosmic import Cosm, Spacecraft
+from nyx_space.mission_design import SpacecraftDynamics, TrajectoryLoader, propagate
 from nyx_space.orbit_determination import (
-    GroundStation,
-    GroundTrackingArcSim,
-    TrkConfig,
-    OrbitEstimate,
-    process_tracking_arc,
-    predictor,
     DynamicTrackingArc,
     ExportCfg,
+    GroundStation,
+    GroundTrackingArcSim,
+    OrbitEstimate,
+    TrkConfig,
+    predictor,
+    process_tracking_arc,
 )
-from nyx_space.mission_design import TrajectoryLoader, SpacecraftDynamics, propagate
-from nyx_space.cosmic import Spacecraft, Cosm
-from nyx_space.time import Unit, TimeSeries
 from nyx_space.plots.od import (
     plot_covar,
     plot_estimates,
-    plot_residuals,
     plot_residual_histogram,
+    plot_residuals,
 )
 from nyx_space.plots.traj import plot_orbit_elements
-from nyx_space.analysis import diff_traj_parquet
+from nyx_space.time import TimeSeries, Unit
 
 
 def test_filter_arc():
@@ -100,6 +101,13 @@ def test_filter_arc():
     orbit_est = OrbitEstimate(
         sc.orbit, covar=np.diag([100.0, 100.0, 100.0, 1.0, 1.0, 1.0])
     )
+
+    # Check loading from the YAML read from Python
+    with open(config_path.joinpath("orbit_estimates.yaml")) as fh:
+        data = yaml.safe_load(fh)
+
+    loaded = OrbitEstimate.loads(data["example 1"])
+    print(loaded)
 
     msr_noise = [1e-3, 0, 0, 1e-6]
     # Switch from sequential to EKF after 100 measurements

--- a/tests/python/test_yaml.py
+++ b/tests/python/test_yaml.py
@@ -1,0 +1,138 @@
+from nyx_space.orbit_determination import GroundStation, GaussMarkov
+from nyx_space.time import Unit
+
+import pickle
+
+gs_data = {
+    "one": {
+        "name": "Santiago, CL",
+        "frame": "IAU Earth",
+        "elevation_mask_deg": 5.0,
+        "range_noise_km": {
+            "tau": "24 h",
+            "bias_sigma": 0.005,
+            "steady_state_sigma": 0.0001,
+        },
+        "doppler_noise_km_s": {
+            "tau": "24h",
+            "bias_sigma": 5e-05,
+            "steady_state_sigma": 1.5e-06,
+        },
+        "light_time_correction": False,
+        "latitude_deg": -33.447487,
+        "longitude_deg": -70.673676,
+        "height_km": 0.5,
+    },
+    "two": {
+        "name": "South Point, Hawaii, US",
+        "frame": "IAU Earth",
+        "latitude_deg": 18.911057,
+        "longitude_deg": -155.681022,
+        "height_km": 0.5,
+        "elevation_mask_deg": 5.0,
+        "range_noise_km": {
+            "tau": "24 h",
+            "bias_sigma": 0.005,
+            "steady_state_sigma": 0.0001,
+        },
+        "doppler_noise_km_s": {
+            "tau": "24 h",
+            "bias_sigma": 5e-05,
+            "steady_state_sigma": 1.5e-06,
+        },
+        "light_time_correction": False,
+    },
+    "three": {
+        "name": "Dongara, AU",
+        "frame": "IAU Earth",
+        "latitude_deg": -29.251281,
+        "longitude_deg": 114.934621,
+        "height_km": 0.5,
+        "elevation_mask_deg": 5.0,
+        "range_noise_km": {
+            "tau": "24 h",
+            "bias_sigma": 0.005,
+            "steady_state_sigma": 0.0001,
+        },
+        "doppler_noise_km_s": {
+            "tau": "24 h",
+            "bias_sigma": 5e-05,
+            "steady_state_sigma": 1.5e-06,
+        },
+        "light_time_correction": False,
+    },
+    "four": {
+        "name": "Maspalomas, ES",
+        "frame": "IAU Earth",
+        "latitude_deg": 27.760562,
+        "longitude_deg": -15.586017,
+        "height_km": 0.5,
+        "elevation_mask_deg": 5.0,
+        "range_noise_km": {
+            "tau": "24 h",
+            "bias_sigma": 0.005,
+            "steady_state_sigma": 0.0001,
+        },
+        "doppler_noise_km_s": {
+            "tau": "24 h",
+            "bias_sigma": 5e-05,
+            "steady_state_sigma": 1.5e-06,
+        },
+        "light_time_correction": False,
+    },
+}
+
+gm_data = {
+    "range_noise_km": {
+        "tau": "24 h",
+        "bias_sigma": 0.005,
+        "steady_state_sigma": 0.0001,
+    },
+    "doppler_noise_km_s": {
+        "tau": "24h",
+        "bias_sigma": 5e-05,
+        "steady_state_sigma": 1.5e-06,
+    },
+}
+
+
+def test_ground_station():
+    # Test that we can load a ground station from a list
+    from_list = GroundStation.loads(list(gs_data.values()))
+    assert len(from_list) == 4
+
+    # Test that we can load a ground station from a dict
+    from_dict = GroundStation.loads(gs_data)
+    assert len(from_dict) == 4
+
+    # Test that we can load a ground station from a single dict definition
+    fourth = gs_data["four"]
+    fourth.pop("range_noise_km")
+    fourth.pop("doppler_noise_km_s")
+    # Using loads
+    unique = GroundStation(**fourth)
+    assert unique.name == "Maspalomas, ES"
+
+    # Or the constructor
+    unique = GroundStation(**fourth)
+    assert unique.name == "Maspalomas, ES"
+
+    # Check pickle
+    pkld = pickle.dumps(unique)
+    unpkld = pickle.loads(pkld)
+    assert unpkld.name == "Maspalomas, ES"
+
+
+def test_gauss_markov():
+    from_list = GaussMarkov.loads(list(gm_data.values()))
+    assert len(from_list) == 2
+
+    unique_range = GaussMarkov.loads(gm_data["range_noise_km"])[0]
+    assert unique_range.tau == Unit.Day * 1.0
+
+    # NOTE: We cannot pickle GaussMarkov because it includes hifitime Duration which is of type `builtin.Duration` and I can't change that.
+
+
+if __name__ == "__main__":
+    test_ground_station()
+    test_gauss_markov()


### PR DESCRIPTION
### Effects
One can now pickle the following data:
- TrkConfig
- FltResid
- GaussMarkov
- GroundStation
- Spacecraft
- SRPConfig
- DragConfig
The following structures can now be _loaded_ from YAML read by Python but not exported:
- OrbitEstimate
- SpacecraftDynamics

Moreover, the `==` in Python is now correctly supported wherever it was incorrect set up. 

- [x] More testing is needed before merging this

### If this is a new feature or a bug fix ...
- [x] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [x] No.
