### PR TITLE
Support estimation of spacecraft coefficient of reflectivity and drag

### DIFF
--- a/src/cosmic/orbitdual.rs
+++ b/src/cosmic/orbitdual.rs
@@ -303,7 +303,7 @@ impl OrbitDual {
         .cross(&self.hvec());
         let aop = (n.dot(&self.evec()?) / (norm(&n) * self.ecc()?.dual)).acos();
         if aop.is_nan() {
-            error!("AoP is NaN");
+            warn!("AoP is NaN");
             Ok(OrbitPartial {
                 dual: OHyperdual::from(0.0),
                 param: StateParameter::AoP,

--- a/src/cosmic/spacecraft.rs
+++ b/src/cosmic/spacecraft.rs
@@ -497,7 +497,7 @@ impl State for Spacecraft {
         self.orbit.epoch = epoch;
         self.orbit.radius_km = radius_km;
         self.orbit.velocity_km_s = vel_km_s;
-        self.srp.cr = sc_state[6];
+        self.srp.cr = sc_state[6].clamp(0.0, 2.0);
         self.drag.cd = sc_state[7];
         self.fuel_mass_kg = sc_state[8];
     }
@@ -788,7 +788,7 @@ impl Add<OVector<f64, Const<9>>> for Spacecraft {
 
         self.orbit.radius_km += radius_km;
         self.orbit.velocity_km_s += vel_km_s;
-        self.srp.cr += other[6];
+        self.srp.cr = (self.srp.cr + other[6]).clamp(0.0, 2.0);
         self.drag.cd += other[7];
         self.fuel_mass_kg += other[8];
 

--- a/src/dynamics/drag.rs
+++ b/src/dynamics/drag.rs
@@ -61,7 +61,7 @@ impl fmt::Display for ConstantDrag {
 
 impl ForceModel for ConstantDrag {
     fn estimation_index(&self) -> Option<usize> {
-        Some(8)
+        Some(7)
     }
 
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {

--- a/src/dynamics/drag.rs
+++ b/src/dynamics/drag.rs
@@ -24,7 +24,7 @@ use super::{
     DynamicsAlmanacSnafu, DynamicsAstroSnafu, DynamicsError, DynamicsPlanetarySnafu, ForceModel,
 };
 use crate::cosmic::{AstroError, AstroPhysicsSnafu, Frame, Spacecraft};
-use crate::linalg::{Matrix3, Vector3};
+use crate::linalg::{Matrix4x3, Vector3};
 use std::fmt;
 use std::sync::Arc;
 
@@ -60,6 +60,10 @@ impl fmt::Display for ConstantDrag {
 }
 
 impl ForceModel for ConstantDrag {
+    fn estimation_index(&self) -> Option<usize> {
+        Some(8)
+    }
+
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
         let osc = almanac
             .transform_to(ctx.orbit, self.drag_frame, None)
@@ -76,7 +80,7 @@ impl ForceModel for ConstantDrag {
         &self,
         _osc_ctx: &Spacecraft,
         _almanac: Arc<Almanac>,
-    ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError> {
+    ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError> {
         Err(DynamicsError::DynamicsAstro {
             source: AstroError::PartialsUndefined,
         })
@@ -135,6 +139,10 @@ impl fmt::Display for Drag {
 }
 
 impl ForceModel for Drag {
+    fn estimation_index(&self) -> Option<usize> {
+        Some(8)
+    }
+
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
         let integration_frame = ctx.orbit.frame;
 
@@ -227,7 +235,7 @@ impl ForceModel for Drag {
         &self,
         _osc_ctx: &Spacecraft,
         _almanac: Arc<Almanac>,
-    ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError> {
+    ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError> {
         Err(DynamicsError::DynamicsAstro {
             source: AstroError::PartialsUndefined,
         })

--- a/src/dynamics/drag.rs
+++ b/src/dynamics/drag.rs
@@ -47,6 +47,8 @@ pub struct ConstantDrag {
     pub rho: f64,
     /// Geoid causing the drag
     pub drag_frame: Frame,
+    /// Set to true to estimate the coefficient of drag
+    pub estimate: bool,
 }
 
 impl fmt::Display for ConstantDrag {
@@ -61,7 +63,11 @@ impl fmt::Display for ConstantDrag {
 
 impl ForceModel for ConstantDrag {
     fn estimation_index(&self) -> Option<usize> {
-        Some(7)
+        if self.estimate {
+            Some(7)
+        } else {
+            None
+        }
     }
 
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
@@ -94,6 +100,8 @@ pub struct Drag {
     pub density: AtmDensity,
     /// Frame to compute the drag in
     pub drag_frame: Frame,
+    /// Set to true to estimate the coefficient of drag
+    pub estimate: bool,
 }
 
 impl Drag {
@@ -110,6 +118,7 @@ impl Drag {
                     action: "planetary data from third body not loaded",
                 }
             })?,
+            estimate: false,
         }))
     }
 
@@ -124,6 +133,7 @@ impl Drag {
                     action: "planetary data from third body not loaded",
                 }
             })?,
+            estimate: false,
         }))
     }
 }
@@ -140,7 +150,11 @@ impl fmt::Display for Drag {
 
 impl ForceModel for Drag {
     fn estimation_index(&self) -> Option<usize> {
-        Some(8)
+        if self.estimate {
+            Some(7)
+        } else {
+            None
+        }
     }
 
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {

--- a/src/dynamics/solarpressure.rs
+++ b/src/dynamics/solarpressure.rs
@@ -96,7 +96,7 @@ impl SolarPressure {
 
 impl ForceModel for SolarPressure {
     fn estimation_index(&self) -> Option<usize> {
-        Some(7)
+        Some(6)
     }
 
     fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
@@ -183,7 +183,7 @@ impl ForceModel for SolarPressure {
         }
 
         // Compute the partial wrt to Cr.
-        let wrt_cr = self.eom(ctx, almanac)?;
+        let wrt_cr = self.eom(ctx, almanac)? / ctx.srp.cr;
         for j in 0..3 {
             grad[(3, j)] = wrt_cr[j];
         }

--- a/src/dynamics/spacecraft.rs
+++ b/src/dynamics/spacecraft.rs
@@ -412,19 +412,19 @@ impl Dynamics for SpacecraftDynamics {
                 // Add the velocity changes
                 d_x[i + 3] += model_frc[i] / total_mass;
                 // Add the velocity partials
-                for j in 1..4 {
-                    grad[(i + 3, j - 1)] += model_grad[(i, j - 1)] / total_mass;
+                for j in 0..3 {
+                    grad[(i + 3, j)] += model_grad[(i, j)] / total_mass;
                 }
             }
             // Add this force model's estimation if applicable.
             if let Some(idx) = model.estimation_index() {
                 for j in 0..3 {
-                    grad[(idx, j)] += model_grad[(3, j)] / total_mass;
+                    grad[(j, idx)] += model_grad[(3, j)] / total_mass;
                 }
-                // d_x[idx] = 1.0;
             }
         }
 
+        // println!("{grad:.6e}");
         Ok((d_x, grad))
     }
 }

--- a/src/dynamics/spacecraft.rs
+++ b/src/dynamics/spacecraft.rs
@@ -419,12 +419,16 @@ impl Dynamics for SpacecraftDynamics {
             // Add this force model's estimation if applicable.
             if let Some(idx) = model.estimation_index() {
                 for j in 0..3 {
-                    grad[(j, idx)] += model_grad[(3, j)] / total_mass;
+                    // XXX: When using (idx, j) and the H is zeroed, there is a very small change in the estimation of the Cr: 1.49999857 instead of 1.5
+                    // When using (j, idx) and H is zeroed, there is a HUGE change in Cr.
+                    // So obviously the former is _more_ correct. But I would expect that the estimation behaves no differently when H is zeroed
+                    // because it means that there is no contribution of that measurement to the Cr value.
+                    grad[(idx, j + 3)] += total_mass / model_grad[(3, j)];
                 }
+                // println!("{grad:e}");
             }
         }
 
-        // println!("{grad:.6e}");
         Ok((d_x, grad))
     }
 }

--- a/src/dynamics/spacecraft.rs
+++ b/src/dynamics/spacecraft.rs
@@ -281,8 +281,8 @@ impl Dynamics for SpacecraftDynamics {
                     d_x[i] = *val;
                 }
 
-                for (i, val) in stm_dt.iter().enumerate() {
-                    d_x[i + <Spacecraft as State>::Size::dim()] = *val;
+                for (i, val) in stm_dt.iter().copied().enumerate() {
+                    d_x[i + <Spacecraft as State>::Size::dim()] = val;
                 }
             }
             None => {
@@ -291,9 +291,10 @@ impl Dynamics for SpacecraftDynamics {
                     .orbital_dyn
                     .eom(&osc_sc.orbit, almanac.clone())?
                     .iter()
+                    .copied()
                     .enumerate()
                 {
-                    d_x[i] = *val;
+                    d_x[i] = val;
                 }
 
                 // Apply the force models for non STM propagation
@@ -414,6 +415,13 @@ impl Dynamics for SpacecraftDynamics {
                 for j in 1..4 {
                     grad[(i + 3, j - 1)] += model_grad[(i, j - 1)] / total_mass;
                 }
+            }
+            // Add this force model's estimation if applicable.
+            if let Some(idx) = model.estimation_index() {
+                for j in 0..3 {
+                    grad[(idx, j)] += model_grad[(3, j)] / total_mass;
+                }
+                // d_x[idx] = 1.0;
             }
         }
 

--- a/src/dynamics/spacecraft.rs
+++ b/src/dynamics/spacecraft.rs
@@ -419,11 +419,8 @@ impl Dynamics for SpacecraftDynamics {
             // Add this force model's estimation if applicable.
             if let Some(idx) = model.estimation_index() {
                 for j in 0..3 {
-                    grad[(idx, j)] += model_grad[(3, j)] / total_mass;
+                    grad[(j + 3, idx)] += model_grad[(3, j)] / total_mass;
                 }
-                // grad[(idx, j)] += model_grad[(3, j)] / total_mass;
-                // Cr = 1.4999976638233514 +/-0.20000001212152405
-                // RMAG error = 0.815728 m VMAG error = 1.346671 mm/s
             }
         }
 

--- a/src/dynamics/spacecraft.rs
+++ b/src/dynamics/spacecraft.rs
@@ -419,13 +419,11 @@ impl Dynamics for SpacecraftDynamics {
             // Add this force model's estimation if applicable.
             if let Some(idx) = model.estimation_index() {
                 for j in 0..3 {
-                    // XXX: When using (idx, j) and the H is zeroed, there is a very small change in the estimation of the Cr: 1.49999857 instead of 1.5
-                    // When using (j, idx) and H is zeroed, there is a HUGE change in Cr.
-                    // So obviously the former is _more_ correct. But I would expect that the estimation behaves no differently when H is zeroed
-                    // because it means that there is no contribution of that measurement to the Cr value.
-                    grad[(idx, j + 3)] += total_mass / model_grad[(3, j)];
+                    grad[(idx, j)] += model_grad[(3, j)] / total_mass;
                 }
-                // println!("{grad:e}");
+                // grad[(idx, j)] += model_grad[(3, j)] / total_mass;
+                // Cr = 1.4999976638233514 +/-0.20000001212152405
+                // RMAG error = 0.815728 m VMAG error = 1.346671 mm/s
             }
         }
 

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -296,7 +296,6 @@ where
         let epoch = nominal_state.epoch();
 
         let mut covar_bar = stm * self.prev_estimate.covar * stm.transpose();
-        let mut snc_used = false;
         // Try to apply an SNC, if applicable
         for (i, snc) in self.process_noise.iter().enumerate().rev() {
             if let Some(snc_matrix) = snc.to_matrix(epoch) {
@@ -335,14 +334,9 @@ where
                 }
                 // Let's add the process noise
                 covar_bar += &gamma * snc_matrix * &gamma.transpose();
-                snc_used = true;
                 // And break so we don't add any more process noise
                 break;
             }
-        }
-
-        if !snc_used {
-            debug!("@{} No SNC", epoch);
         }
 
         let h_tilde_t = &self.h_tilde.transpose();

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -365,12 +365,12 @@ where
         }
 
         // Compute the Kalman gain but first adding the measurement noise to H⋅P⋅H^T
-        let mut invertible_part = h_p_ht + &r_k;
-        if !invertible_part.try_inverse_mut() {
+        let mut innovation_covar = h_p_ht + &r_k;
+        if !innovation_covar.try_inverse_mut() {
             return Err(ODError::SingularKalmanGain);
         }
 
-        let gain = covar_bar * h_tilde_t * &invertible_part;
+        let gain = covar_bar * h_tilde_t * &innovation_covar;
 
         // Compute the state estimate
         let (state_hat, res) = if self.ekf {

--- a/src/od/msr/range_doppler.rs
+++ b/src/od/msr/range_doppler.rs
@@ -164,6 +164,11 @@ impl EstimateFrom<Spacecraft, RangeDoppler> for Spacecraft {
         let m22 = delta_v.y / ρ - ρ_dot * delta_r.y / ρ.powi(2);
         let m23 = delta_v.z / ρ - ρ_dot * delta_r.z / ρ.powi(2);
 
+        let stm = receiver.stm.unwrap();
+        let ρ_wrt_cr = stm[(6, 0)] * m11 + stm[(6, 1)] * m12 + stm[(6, 2)] * m13;
+
+        let ρ_dot_wrt_cr = stm[(6, 0)] * m21 + stm[(6, 1)] * m22 + stm[(6, 2)] * m23;
+
         let items = &[
             m11, m12, m13, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
             0.0,

--- a/src/od/msr/range_doppler.rs
+++ b/src/od/msr/range_doppler.rs
@@ -164,11 +164,6 @@ impl EstimateFrom<Spacecraft, RangeDoppler> for Spacecraft {
         let m22 = delta_v.y / ρ - ρ_dot * delta_r.y / ρ.powi(2);
         let m23 = delta_v.z / ρ - ρ_dot * delta_r.z / ρ.powi(2);
 
-        let stm = receiver.stm.unwrap();
-        let ρ_wrt_cr = stm[(6, 0)] * m11 + stm[(6, 1)] * m12 + stm[(6, 2)] * m13;
-
-        let ρ_dot_wrt_cr = stm[(6, 0)] * m21 + stm[(6, 1)] * m22 + stm[(6, 2)] * m23;
-
         let items = &[
             m11, m12, m13, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
             0.0,

--- a/src/od/msr/range_doppler.rs
+++ b/src/od/msr/range_doppler.rs
@@ -165,7 +165,7 @@ impl EstimateFrom<Spacecraft, RangeDoppler> for Spacecraft {
         let m23 = delta_v.z / ρ - ρ_dot * delta_r.z / ρ.powi(2);
 
         let items = &[
-            m11, m12, m13, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
+            m11, m12, m13, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
             0.0,
         ];
 

--- a/src/od/msr/range_doppler.rs
+++ b/src/od/msr/range_doppler.rs
@@ -165,7 +165,7 @@ impl EstimateFrom<Spacecraft, RangeDoppler> for Spacecraft {
         let m23 = delta_v.z / ρ - ρ_dot * delta_r.z / ρ.powi(2);
 
         let items = &[
-            m11, m12, m13, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
+            m11, m12, m13, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, m21, m22, m23, m11, m12, m13, 0.0, 0.0,
             0.0,
         ];
 

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -156,7 +156,7 @@ where
     ) -> Self {
         let init_state = prop.state;
         Self {
-            prop,
+            prop: prop.quiet(),
             kf,
             estimates: Vec::with_capacity(10_000),
             residuals: Vec::with_capacity(10_000),
@@ -794,7 +794,7 @@ where
     ) -> Self {
         let init_state = prop.state;
         Self {
-            prop,
+            prop: prop.quiet(),
             kf,
             estimates: Vec::with_capacity(10_000),
             residuals: Vec::with_capacity(10_000),

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -403,9 +403,9 @@ fn od_val_sc_srp_estimation(
     let initial_estimate = sc.to_estimate().unwrap();
 
     // let ckf = KF::no_snc(initial_estimate);
-    let ckf = KF::new(
+    let ckf = KF::no_snc(
         initial_estimate,
-        SNC3::from_diagonal(2 * Unit::Minute, &[1e-12, 1e-12, 1e-12]),
+        // SNC3::from_diagonal(2 * Unit::Minute, &[1e-14, 1e-14, 1e-14]),
     );
 
     let mut odp = ODProcess::ekf(

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -300,8 +300,8 @@ fn od_val_sc_srp_estimation(
     // Define state information.
     let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
     // Using a GTO because Cr estimation will be more obvious.
-    // let initial_orbit = Orbit::keplerian(24505.9, 0.725, 7.05, 0.0, 0.0, 0.0, epoch, eme2k);
-    let initial_orbit = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, epoch, eme2k);
+    let initial_orbit = Orbit::keplerian(24505.9, 0.725, 7.05, 0.0, 0.0, 0.0, epoch, eme2k);
+    // let initial_orbit = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, epoch, eme2k);
     // let prop_time = initial_orbit.period().unwrap() * 0.5;
     let prop_time = 1 * Unit::Day;
 

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -446,8 +446,8 @@ fn od_val_sc_srp_estimation(
     assert!(delta.rmag_km() < 1e-3, "More than 1 meter error");
     assert!(delta.vmag_km_s() < 1e-6, "More than 1 millimeter/s error");
     assert!(
-        (est.state().srp.cr - truth_cr).abs() < 0.038,
-        "Cr estimation worst than expected"
+        (est.state().srp.cr - truth_cr).abs() < (1.5 - truth_cr),
+        "Cr estimation did not improve"
     );
 
     for (no, est) in odp.estimates.iter().enumerate() {

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -446,8 +446,8 @@ fn od_val_sc_srp_estimation(
     assert!(delta.rmag_km() < 1e-3, "More than 1 meter error");
     assert!(delta.vmag_km_s() < 1e-6, "More than 1 millimeter/s error");
     assert!(
-        (est.state().srp.cr - truth_cr).abs() < 0.377,
-        "Cr estimation did not decrease"
+        (est.state().srp.cr - truth_cr).abs() < 0.038,
+        "Cr estimation worst than expected"
     );
 
     for (no, est) in odp.estimates.iter().enumerate() {


### PR DESCRIPTION
# Summary

This change enables the estimation of Cr and Cd in the orbit determination of Nyx. This change has long been coming.

The SRP estimation model is **finicky.** You will NEED to enable some level of state noise compensation. The ODTK MathSpec (page 179) recommends modeling the SRP as a first order Gauss Markov process, which accounts for the time between measurements to even out the partial of the Cr. Instead, _Nyx estimates Cr directly_, assuming that it is a fixed value. This means that the filter is _very_ (too?) responsive to changes in Cr. Too much SNC, and the Cr estimation does not happen because the changes are absorbed by the SNC, and too little, and you'll end up with a very slow estimation, and a Cr value that fluctuates a lot.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

Implementations of `ForceModel` now return a rectangular Matrix where the extra data corresponds to the partial of that parameter (expected in the estimated state) wrt the velocity components.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Add the `od_val_sc_srp_estimation` test case. In this test case, tracking data is simulated for a GTO with a Cr of `1.123`, over 5 orbital periods (or 2 d 5 h). The initial estimation state is the same as the original one, but the Cr value is 1.5. The purpose of this test is to ensure that the estimated Cr converges onto the one from the tracking data.

![newplot(1)](https://github.com/user-attachments/assets/9d75a86a-fb43-4641-94b0-9811a358e5c7)
![newplot(2)](https://github.com/user-attachments/assets/f16de6cb-ac4b-4876-843e-dd04cfc3acf8)


## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->