### PR TITLE
Bound the proposed integrator steps

### DIFF
--- a/src/propagators/mod.rs
+++ b/src/propagators/mod.rs
@@ -16,6 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+use anise::errors::MathError;
 use snafu::prelude::*;
 use std::fmt;
 
@@ -66,4 +67,6 @@ pub enum PropagationError {
     NthEventError { nth: usize, found: usize },
     #[snafu(display("propagation failed because {source}"))]
     PropConfigError { source: ConfigError },
+    #[snafu(display("propagation encountered a math error {source}"))]
+    PropMathError { source: MathError },
 }

--- a/src/propagators/options.rs
+++ b/src/propagators/options.rs
@@ -144,17 +144,6 @@ impl IntegratorOptions {
         }
         self.min_step = min_step;
     }
-
-    /// Returns a proposed step in seconds that is within the bounds of these integrator options.
-    pub(crate) fn bound_proposed_step(&self, proposed_step_s: f64) -> f64 {
-        if proposed_step_s > self.max_step.to_seconds() {
-            self.max_step.to_seconds()
-        } else if proposed_step_s < self.min_step.to_seconds() {
-            self.min_step.to_seconds()
-        } else {
-            proposed_step_s
-        }
-    }
 }
 
 impl fmt::Display for IntegratorOptions {

--- a/src/propagators/options.rs
+++ b/src/propagators/options.rs
@@ -144,6 +144,17 @@ impl IntegratorOptions {
         }
         self.min_step = min_step;
     }
+
+    /// Returns a proposed step in seconds that is within the bounds of these integrator options.
+    pub(crate) fn bound_proposed_step(&self, proposed_step_s: f64) -> f64 {
+        if proposed_step_s > self.max_step.to_seconds() {
+            self.max_step.to_seconds()
+        } else if proposed_step_s < self.min_step.to_seconds() {
+            self.min_step.to_seconds()
+        } else {
+            proposed_step_s
+        }
+    }
 }
 
 impl fmt::Display for IntegratorOptions {

--- a/tests/orbit_determination/spacecraft.rs
+++ b/tests/orbit_determination/spacecraft.rs
@@ -329,7 +329,7 @@ fn od_val_sc_srp_estimation(
     let setup = Propagator::dp78(
         sc_dynamics,
         IntegratorOptions::builder()
-            .max_step(1.minutes())
+            .max_step(30.seconds())
             .error_ctrl(ErrorControl::RSSCartesianStep)
             .build(),
     );


### PR DESCRIPTION
# Summary

The minimum step check was sometimes bypassed when updating the step size for the next integration cycle. This could cause the minimum integration step size to be zero, thereby hanging forever. This PR also prevents NaN from showing up in the solution of an integration by stopping the integration and recommending solutions.

This PR fixes #377 where this bug was identified. Thanks @gregjesl !

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

Propagation reporting now shows the current step size as well.

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Integrator steps are now always within integrator option bounds.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

No changes to the test themselves, but I tested the fix on the code from the bug report.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->