### PR TITLE
Added template method for mean surface event

### DIFF
--- a/src/md/events/mod.rs
+++ b/src/md/events/mod.rs
@@ -26,6 +26,7 @@ use crate::linalg::DefaultAllocator;
 use crate::time::{Duration, Unit};
 use crate::State;
 use anise::prelude::{Almanac, Frame};
+use anise::structure::planetocentric::ellipsoid::Ellipsoid;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use std::default::Default;
@@ -152,6 +153,12 @@ impl Event {
     /// Match the apoapasis i.e. True Anomaly == 180
     pub fn apoapsis() -> Self {
         Self::new(StateParameter::Apoapsis, 180.0)
+    }
+
+    /// Match the central body's mean equatorial radius.
+    /// This is useful for detecting when an object might impact the central body.
+    pub fn mean_surface(body: &Ellipsoid) -> Self {
+        Self::new(StateParameter::Rmag, body.mean_equatorial_radius_km())
     }
 
     /// Match a specific event in another frame, using the default epoch precision and value.


### PR DESCRIPTION
# Summary

Added event template for detecting central body collisions. 

## Architectural Changes

No change

## New Features

Added a method for generating an event that detects when an orbit crosses the mean equatorial radius of a central body. This is useful for approximating when an object might impact the central body. 

No change

## Improvements

Simplifies the search for trajectories that might impact the central body. 

No change

## Bug Fixes

No change

## Testing and validation

Tested in simulation. 

## Documentation

This PR does not primarily deal with documentation changes.