### PR TITLE
Aligned comment with trajectory arguments

### DIFF
--- a/examples/04_lro_od/main.rs
+++ b/examples/04_lro_od/main.rs
@@ -86,7 +86,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .orbit(Orbit::zero(MOON_J2000)) // Setting a zero orbit here because it's just a template
         .build();
     // Now we can build the trajectory from the BSP file.
-    // We'll arbitrarily set the tracking arc to 48 hours with a one minute time step.
+    // We'll arbitrarily set the tracking arc to 24 hours with a five second time step.
     let traj_as_flown = Traj::from_bsp(
         lro_frame,
         MOON_J2000,


### PR DESCRIPTION
# Summary

Fixes mismatch between comments and implementation

## Architectural Changes

No change

## New Features

No change

## Improvements

No change

## Bug Fixes

No change

## Testing and validation

No change to code

## Documentation

Original comment stated
https://github.com/nyx-space/nyx/blob/1378c5b9065c82f7145891ba0b03038fef25da9a/examples/04_lro_od/main.rs#L89
but actual arguments are
https://github.com/nyx-space/nyx/blob/1378c5b9065c82f7145891ba0b03038fef25da9a/examples/04_lro_od/main.rs#L95-L97
which is a five-second interval over 24 hours, not a one-minute interval over 48 hours. 