### PR TITLE
Orbit determination constant biases + measurement ambiguity and moduli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nyx-space"
 build = "build.rs"
-version = "2.1.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "A high-fidelity space mission toolkit, with orbit propagation, estimation and some systems engineering"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nyx-space"
 build = "build.rs"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "A high-fidelity space mission toolkit, with orbit propagation, estimation and some systems engineering"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ For Python projects, get started by installing the library via `pip`: `pip insta
 
 Nyx is provided under the [AGPLv3 License](./LICENSE). By using this software, you assume responsibility for adhering to the license. Refer to [the pricing page](https://nyxspace.com/pricing/?utm_source=readme-price) for an FAQ on the AGPLv3 license. Notably, any software that incorporates, links to, or depends on Nyx must also be released under the AGPLv3 license, even if you distribute an unmodified version of Nyx.
 
+# Versioning
+
+Nyx mostly adheres to SemVer. New patch versions should be rare. Updated dependencies trigger a new minor version. _However_ new fields in structures and new behavior may also be added with minor releases, but the public facing initializers and functions should not significantly change (but may still change).
+
+Major releases are for dramatic changes.
+
 
 [cratesio-image]: https://img.shields.io/crates/v/nyx-space.svg
 [cratesio]: https://crates.io/crates/nyx-space

--- a/data/tests/config/high-prec-network.yaml
+++ b/data/tests/config/high-prec-network.yaml
@@ -1,7 +1,9 @@
 range_noise_model:
   tau: 12 h 159 ms
   process_noise: 5.0e-3 # 5 m
+  constant: 0
 
 doppler_noise_model:
   tau: 11 h 59 min
   process_noise: 50.0e-6 # 5 cm/s
+  constant: 0

--- a/data/tests/config/high-prec-network.yaml
+++ b/data/tests/config/high-prec-network.yaml
@@ -1,9 +1,7 @@
 range_noise_model:
   tau: 12 h 159 ms
   process_noise: 5.0e-3 # 5 m
-  constant: 0
 
 doppler_noise_model:
   tau: 11 h 59 min
   process_noise: 50.0e-6 # 5 cm/s
-  constant: 0

--- a/data/tests/config/many_ground_stations.yaml
+++ b/data/tests/config/many_ground_stations.yaml
@@ -10,10 +10,12 @@
       bias:
         tau: 24 h
         process_noise: 5.0e-3 # 5 m
+        constant: 0
     doppler_km_s:
       bias:
         tau: 24 h
         process_noise: 50.0e-6 # 5 cm/s
+        constant: 0
   light_time_correction: false
   latitude_deg: 2.3522
   longitude_deg: 48.8566
@@ -37,10 +39,12 @@
       bias:
         tau: 24 h
         process_noise: 5.0e-3 # 5 m
+        constant: 0
     doppler_km_s:
       bias:
         tau: 24 h
         process_noise: 50.0e-6 # 5 cm/s
+        constant: 0
   light_time_correction: false
   measurement_types:
     - range_km

--- a/data/tests/config/many_ground_stations.yaml
+++ b/data/tests/config/many_ground_stations.yaml
@@ -10,12 +10,10 @@
       bias:
         tau: 24 h
         process_noise: 5.0e-3 # 5 m
-        constant: 0
     doppler_km_s:
       bias:
         tau: 24 h
         process_noise: 50.0e-6 # 5 cm/s
-        constant: 0
   light_time_correction: false
   latitude_deg: 2.3522
   longitude_deg: 48.8566
@@ -39,12 +37,10 @@
       bias:
         tau: 24 h
         process_noise: 5.0e-3 # 5 m
-        constant: 0
     doppler_km_s:
       bias:
         tau: 24 h
         process_noise: 50.0e-6 # 5 cm/s
-        constant: 0
   light_time_correction: false
   measurement_types:
     - range_km

--- a/data/tests/config/one_ground_station.yaml
+++ b/data/tests/config/one_ground_station.yaml
@@ -13,10 +13,12 @@ stochastic_noises:
     bias:
       tau: 24 h
       process_noise: 5.0e-3 # 5 m
+      constant: 0
   doppler_km_s:
     bias:
       tau: 24 h
       process_noise: 50.0e-6 # 5 cm/s
+      constant: 0
 light_time_correction: false
 measurement_types:
     - range_km

--- a/data/tests/config/one_ground_station.yaml
+++ b/data/tests/config/one_ground_station.yaml
@@ -13,12 +13,10 @@ stochastic_noises:
     bias:
       tau: 24 h
       process_noise: 5.0e-3 # 5 m
-      constant: 0
   doppler_km_s:
     bias:
       tau: 24 h
       process_noise: 50.0e-6 # 5 cm/s
-      constant: 0
 light_time_correction: false
 measurement_types:
     - range_km

--- a/examples/04_lro_od/plot_od_rslt.py
+++ b/examples/04_lro_od/plot_od_rslt.py
@@ -9,7 +9,8 @@ import click
 
 @click.command
 @click.option("-p", "--path", type=str, default="./04_lro_od_results.parquet")
-def main(path: str):
+@click.option("-f", "--full", type=bool, default=True)
+def main(path: str, full: bool):
     df = pl.read_parquet(path)
 
     df = (
@@ -122,6 +123,9 @@ def main(path: str):
         x="Epoch (UTC)",
         y=["Sigma Vx (RIC) (km/s)", "Sigma Vy (RIC) (km/s)", "Sigma Vz (RIC) (km/s)"],
     ).show()
+
+    if not full:
+        return
 
     # Load the RIC diff.
     for fname, errname in [

--- a/src/cosmic/orbitdual.rs
+++ b/src/cosmic/orbitdual.rs
@@ -476,7 +476,7 @@ impl OrbitDual {
                 param: StateParameter::MeanAnomaly,
             })
         } else if self.ecc()?.real() > 1.0 {
-            info!("computing the hyperbolic anomaly");
+            debug!("computing the hyperbolic anomaly");
             // From GMAT's TrueToHyperbolicAnomaly
             Ok(OrbitPartial {
                 dual: ((self.ta_deg()?.dual.to_radians().sin()

--- a/src/dynamics/guidance/ruggiero.rs
+++ b/src/dynamics/guidance/ruggiero.rs
@@ -17,6 +17,7 @@
 */
 
 use anise::prelude::Almanac;
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use super::{
@@ -32,7 +33,7 @@ use std::fmt;
 use std::sync::Arc;
 
 /// Ruggiero defines the closed loop guidance law from IEPC 2011-102
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Serialize, Deserialize)]
 pub struct Ruggiero {
     /// Stores the objectives
     pub objectives: [Option<Objective>; 5],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub mod cosmic;
 /// Utility functions shared by different modules, and which may be useful to engineers.
 pub mod utils;
 
-mod errors;
+pub mod errors;
 /// Nyx will (almost) never panic and functions which may fail will return an error.
 pub use self::errors::NyxError;
 

--- a/src/mc/dispersion.rs
+++ b/src/mc/dispersion.rs
@@ -17,10 +17,11 @@
 */
 
 use crate::md::StateParameter;
+use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// A dispersions configuration, allows specifying min/max bounds (by default, they are not set)
-#[derive(Copy, Clone, TypedBuilder)]
+#[derive(Copy, Clone, TypedBuilder, Serialize, Deserialize)]
 pub struct StateDispersion {
     pub param: StateParameter,
     #[builder(default, setter(strip_option))]

--- a/src/md/events/details.rs
+++ b/src/md/events/details.rs
@@ -25,12 +25,13 @@ use crate::md::prelude::{Interpolatable, Traj};
 use crate::md::EventEvaluator;
 use crate::time::Duration;
 use core::fmt;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Enumerates the possible edges of an event in a trajectory.
 ///
 /// `EventEdge` is used to describe the nature of a trajectory event, particularly in terms of its temporal dynamics relative to a specified condition or threshold. This enum helps in distinguishing whether the event is occurring at a rising edge, a falling edge, or if the edge is unclear due to insufficient data or ambiguous conditions.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum EventEdge {
     /// Represents a rising edge of the event. This indicates that the event is transitioning from a lower to a higher evaluation of the event. For example, in the context of elevation, a rising edge would indicate an increase in elevation from a lower angle.
     Rising,
@@ -73,14 +74,14 @@ where
 {
     /// Generates detailed information about an event at a specific epoch in a trajectory.
     ///
-    /// This takes an `Epoch` as an input and returns a `Result<Self, NyxError>`.
+    /// This takes an `Epoch` as an input and returns a `Result<Self, EventError>`.
     /// It is designed to determine the state of a trajectory at a given epoch, evaluate the specific event at that state, and ascertain the nature of the event (rising, falling, or unclear).
     /// The initialization intelligently determines the edge type of the event by comparing the event's value at the current, previous, and next epochs.
     /// It ensures robust event characterization in trajectories.
     ///
     /// # Returns
     /// - `Ok(EventDetails<S>)` if the state at the given epoch can be determined and the event details are successfully evaluated.
-    /// - `Err(NyxError)` if there is an error in retrieving the state at the specified epoch.
+    /// - `Err(EventError)` if there is an error in retrieving the state at the specified epoch.
     ///
     pub fn new<E: EventEvaluator<S>>(
         state: S,

--- a/src/md/events/mod.rs
+++ b/src/md/events/mod.rs
@@ -27,6 +27,7 @@ use crate::time::{Duration, Unit};
 use crate::State;
 use anise::prelude::{Almanac, Frame};
 use anise::structure::planetocentric::ellipsoid::Ellipsoid;
+use serde::{Deserialize, Serialize};
 
 use std::default::Default;
 use std::fmt;
@@ -59,15 +60,14 @@ where
 }
 
 /// Defines a state parameter event finder
-#[derive(Clone, Debug)]
-
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Event {
     /// The state parameter
     pub parameter: StateParameter,
     /// The desired self.desired_value, must be in the same units as the state parameter
     pub desired_value: f64,
-    /// The time precision after which the solver will report that it cannot find any more precise
-    pub epoch_precision: Unit,
+    /// The duration precision after which the solver will report that it cannot find any more precise
+    pub epoch_precision: Duration,
     /// The precision on the desired value
     pub value_precision: f64,
     /// An optional frame in which to search this -- it IS recommended to convert the whole trajectory instead of searching in a given frame!
@@ -133,12 +133,12 @@ impl Event {
         parameter: StateParameter,
         desired_value: f64,
         value_precision: f64,
-        epoch_precision: Unit,
+        unit_precision: Unit,
     ) -> Self {
         Self {
             parameter,
             desired_value,
-            epoch_precision,
+            epoch_precision: 1 * unit_precision,
             value_precision,
             obs_frame: None,
         }
@@ -166,7 +166,7 @@ impl Event {
         Self {
             parameter,
             desired_value,
-            epoch_precision: Unit::Millisecond,
+            epoch_precision: Unit::Millisecond * 1,
             value_precision: 1e-3,
             obs_frame: Some(target_frame),
         }
@@ -179,7 +179,7 @@ impl Default for Event {
             parameter: StateParameter::Periapsis,
             desired_value: 0.0,
             value_precision: 1e-3,
-            epoch_precision: Unit::Second,
+            epoch_precision: Unit::Second * 1,
             obs_frame: None,
         }
     }

--- a/src/md/objective.rs
+++ b/src/md/objective.rs
@@ -18,10 +18,11 @@
 
 use super::StateParameter;
 use crate::{errors::StateError, Spacecraft, State};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Defines a state parameter event finder
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Objective {
     /// The state parameter to target
     pub parameter: StateParameter,

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -300,10 +300,14 @@ where
         // Compute the prefit ratio for the automatic rejection.
         // The measurement covariance is the square of the measurement itself.
         // So we compute its Cholesky decomposition to return to the non squared values.
-        dbg!(epoch);
-        dbg!(&r_k);
-        dbg!(&s_k);
-        let r_k_chol = s_k.clone().cholesky().ok_or(ODError::SingularNoiseRk)?.l();
+        let r_k_chol = match s_k.clone().cholesky() {
+            Some(r_k_clone) => r_k_clone.l(),
+            None => {
+                // In very rare case, when there isn't enough noise in the measurements,
+                // the inverting of S_k fails. If so, we revert back to the nominal Kalman derivation.
+                r_k.clone().cholesky().ok_or(ODError::SingularNoiseRk)?.l()
+            }
+        };
 
         // Compute the ratio as the average of each component of the prefit over the square root of the measurement
         // matrix r_k. Refer to ODTK MathSpec equation 4.10.

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -300,6 +300,9 @@ where
         // Compute the prefit ratio for the automatic rejection.
         // The measurement covariance is the square of the measurement itself.
         // So we compute its Cholesky decomposition to return to the non squared values.
+        dbg!(epoch);
+        dbg!(&r_k);
+        dbg!(&s_k);
         let r_k_chol = s_k.clone().cholesky().ok_or(ODError::SingularNoiseRk)?.l();
 
         // Compute the ratio as the average of each component of the prefit over the square root of the measurement

--- a/src/od/ground_station/trk_device.rs
+++ b/src/od/ground_station/trk_device.rs
@@ -185,7 +185,7 @@ impl TrackingDevice<Spacecraft> for GroundStation {
             })?
             .bias
         {
-            Ok(gm.constant)
+            Ok(gm.constant.unwrap_or(0.0))
         } else {
             Ok(0.0)
         }

--- a/src/od/ground_station/trk_device.rs
+++ b/src/od/ground_station/trk_device.rs
@@ -174,4 +174,20 @@ impl TrackingDevice<Spacecraft> for GroundStation {
             })?
             .covariance(epoch))
     }
+
+    fn measurement_bias(&self, msr_type: MeasurementType, _epoch: Epoch) -> Result<f64, ODError> {
+        let stochastics = self.stochastic_noises.as_ref().unwrap();
+
+        if let Some(gm) = stochastics
+            .get(&msr_type)
+            .ok_or(ODError::NoiseNotConfigured {
+                kind: format!("{msr_type:?}"),
+            })?
+            .bias
+        {
+            Ok(gm.constant)
+        } else {
+            Ok(0.0)
+        }
+    }
 }

--- a/src/od/msr/measurement.rs
+++ b/src/od/msr/measurement.rs
@@ -102,7 +102,7 @@ impl PartialEq for Measurement {
             && self.epoch == other.epoch
             && self.data.iter().all(|(key, &value)| {
                 if let Some(&other_value) = other.data.get(key) {
-                    (value - other_value).abs() < 1e-12
+                    (value - other_value).abs() < 1e-10
                 } else {
                     false
                 }

--- a/src/od/msr/measurement.rs
+++ b/src/od/msr/measurement.rs
@@ -23,7 +23,10 @@ use nalgebra::{allocator::Allocator, DefaultAllocator, DimName, OVector};
 use std::fmt;
 
 /// A type-agnostic simultaneous measurement storage structure. Allows storing any number of simultaneous measurement of a given taker.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// Note that two measurements are considered equal if the tracker and epoch match exactly, and if both have the same measurement types,
+/// and those measurements are equal to within 1e-10 (this allows for some leeway in TDM producers).
+#[derive(Clone, Debug)]
 pub struct Measurement {
     /// Tracker alias which made this measurement
     pub tracker: String,
@@ -58,6 +61,7 @@ impl Measurement {
     where
         DefaultAllocator: Allocator<S>,
     {
+        // Consider adding a modulo modifier here, any bias should be configured by each ground station.
         let mut obs = OVector::zeros();
         for (i, t) in types.iter().enumerate() {
             if let Some(msr_value) = self.data.get(t) {
@@ -89,5 +93,19 @@ impl fmt::Display for Measurement {
             .join(", ");
 
         write!(f, "{} measured {} on {}", self.tracker, msrs, self.epoch)
+    }
+}
+
+impl PartialEq for Measurement {
+    fn eq(&self, other: &Self) -> bool {
+        self.tracker == other.tracker
+            && self.epoch == other.epoch
+            && self.data.iter().all(|(key, &value)| {
+                if let Some(&other_value) = other.data.get(key) {
+                    (value - other_value).abs() < 1e-12
+                } else {
+                    false
+                }
+            })
     }
 }

--- a/src/od/msr/trackingdata/io_ccsds_tdm.rs
+++ b/src/od/msr/trackingdata/io_ccsds_tdm.rs
@@ -257,7 +257,7 @@ impl TrackingDataArc {
                 // Only range modulus exists in TDM files.
                 Some(modulos)
             } else {
-                warn!("could not parse RANGE_MODULO of `{range_modulus}` as a double");
+                warn!("could not parse RANGE_MODULUS of `{range_modulus}` as a double");
                 None
             }
         } else {

--- a/src/od/msr/trackingdata/io_parquet.rs
+++ b/src/od/msr/trackingdata/io_parquet.rs
@@ -43,6 +43,8 @@ use super::TrackingDataArc;
 
 impl TrackingDataArc {
     /// Loads a tracking arc from its serialization in parquet.
+    ///
+    /// Warning: no metadata is read from the parquet file, even that written to it by Nyx.
     pub fn from_parquet<P: AsRef<Path>>(path: P) -> Result<Self, InputOutputError> {
         let file = File::open(&path).context(StdIOSnafu {
             action: "opening file for tracking arc",
@@ -211,6 +213,7 @@ impl TrackingDataArc {
 
         Ok(Self {
             measurements,
+            moduli: None,
             source: Some(path.as_ref().to_path_buf().display().to_string()),
         })
     }
@@ -314,6 +317,12 @@ impl TrackingDataArc {
         if let Some(add_meta) = cfg.metadata {
             for (k, v) in add_meta {
                 metadata.insert(k, v);
+            }
+        }
+
+        if let Some(modulos) = &self.moduli {
+            for (msr_type, v) in modulos {
+                metadata.insert(format!("MODULUS:{msr_type:?}"), v.to_string());
             }
         }
 

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -48,6 +48,19 @@ impl TrackingDataArc {
         self.moduli.as_mut().unwrap().insert(msr_type, modulus);
     }
 
+    /// Applies the moduli to each measurement, if defined.
+    pub fn apply_moduli(&mut self) {
+        if let Some(moduli) = &self.moduli {
+            for msr in self.measurements.values_mut() {
+                for (msr_type, modulus) in moduli {
+                    if let Some(msr_value) = msr.data.get_mut(msr_type) {
+                        *msr_value %= *modulus;
+                    }
+                }
+            }
+        }
+    }
+
     /// Returns the unique list of aliases in this tracking data arc
     pub fn unique_aliases(&self) -> IndexSet<String> {
         self.unique().0

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -39,6 +39,15 @@ pub struct TrackingDataArc {
 }
 
 impl TrackingDataArc {
+    /// Set (or overwrites) the modulus of the provided measurement type.
+    pub fn set_moduli(&mut self, msr_type: MeasurementType, modulus: f64) {
+        if self.moduli.is_none() {
+            self.moduli = Some(IndexMap::new());
+        }
+
+        self.moduli.as_mut().unwrap().insert(msr_type, modulus);
+    }
+
     /// Returns the unique list of aliases in this tracking data arc
     pub fn unique_aliases(&self) -> IndexSet<String> {
         self.unique().0

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -34,6 +34,8 @@ pub struct TrackingDataArc {
     pub measurements: BTreeMap<Epoch, Measurement>, // BUG: Consider a map of tracking to epoch!
     /// Source file if loaded from a file or saved to a file.
     pub source: Option<String>,
+    /// Optionally provide a map of modulos (e.g. the RANGE_MODULO of CCSDS TDM).
+    pub moduli: Option<IndexMap<MeasurementType, f64>>,
 }
 
 impl TrackingDataArc {

--- a/src/od/msr/types.rs
+++ b/src/od/msr/types.rs
@@ -50,6 +50,17 @@ impl MeasurementType {
         }
     }
 
+    /// Returns true if this measurement type could be a two-way measurement.
+    pub(crate) fn may_be_two_way(self) -> bool {
+        match self {
+            MeasurementType::Range | MeasurementType::Doppler => true,
+            MeasurementType::Azimuth
+            | MeasurementType::Elevation
+            | MeasurementType::ReceiveFrequency
+            | MeasurementType::TransmitFrequency => false,
+        }
+    }
+
     /// Returns the fields for this kind of measurement. The metadata includes a `unit` field with the unit.
     /// Column is nullable in case there is no such measurement at a given epoch.
     pub fn to_field(&self) -> Field {

--- a/src/od/noise/gauss_markov.rs
+++ b/src/od/noise/gauss_markov.rs
@@ -23,7 +23,7 @@ use rand::Rng;
 use rand_distr::Normal;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt;
-use std::ops::Mul;
+use std::ops::{Mul, MulAssign};
 
 use super::Stochastics;
 
@@ -153,14 +153,18 @@ impl Mul<f64> for GaussMarkov {
     type Output = Self;
 
     /// Scale the Gauss Markov process by a constant, maintaining the same time constant.
-    fn mul(self, rhs: f64) -> Self::Output {
-        Self {
-            tau: self.tau,
-            process_noise: self.process_noise * rhs,
-            constant: None,
-            init_sample: None,
-            prev_epoch: None,
-        }
+    fn mul(mut self, rhs: f64) -> Self::Output {
+        self.process_noise *= rhs;
+        self.constant = None;
+        self.init_sample = None;
+        self.prev_epoch = None;
+        self
+    }
+}
+
+impl MulAssign<f64> for GaussMarkov {
+    fn mul_assign(&mut self, rhs: f64) {
+        *self = *self * rhs;
     }
 }
 

--- a/src/od/noise/mod.rs
+++ b/src/od/noise/mod.rs
@@ -27,6 +27,7 @@ use rand_pcg::Pcg64Mcg;
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use std::fs::File;
+use std::ops::{Mul, MulAssign};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -209,6 +210,27 @@ impl StochasticNoise {
         writer.close()?;
 
         Ok(samples)
+    }
+}
+
+impl Mul<f64> for StochasticNoise {
+    type Output = Self;
+
+    fn mul(mut self, rhs: f64) -> Self::Output {
+        if let Some(mut wn) = &mut self.white_noise {
+            wn *= rhs;
+        }
+        if let Some(mut gm) = &mut self.bias {
+            gm *= rhs;
+        }
+
+        self
+    }
+}
+
+impl MulAssign<f64> for StochasticNoise {
+    fn mul_assign(&mut self, rhs: f64) {
+        *self = *self * rhs;
     }
 }
 

--- a/src/od/noise/white.rs
+++ b/src/od/noise/white.rs
@@ -16,6 +16,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+use std::ops::{Mul, MulAssign};
+
 use anise::constants::SPEED_OF_LIGHT_KM_S;
 use hifitime::{Duration, Epoch};
 use rand::Rng;
@@ -74,6 +76,22 @@ impl Stochastics for WhiteNoise {
 
     fn sample<R: Rng>(&mut self, _epoch: Epoch, rng: &mut R) -> f64 {
         rng.sample(Normal::new(self.mean, self.sigma).unwrap())
+    }
+}
+
+impl Mul<f64> for WhiteNoise {
+    type Output = Self;
+
+    /// Scale the white noise sigmas by a constant.
+    fn mul(mut self, rhs: f64) -> Self::Output {
+        self.sigma *= rhs;
+        self
+    }
+}
+
+impl MulAssign<f64> for WhiteNoise {
+    fn mul_assign(&mut self, rhs: f64) {
+        *self = *self * rhs;
     }
 }
 

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -560,10 +560,19 @@ where
 
                                     self.kf.update_h_tilde(h_tilde);
 
+                                    let real_obs = msr.observation(&cur_msr_types);
+
+                                    let computed_obs = computed_meas
+                                        .observation::<MsrSize>(&cur_msr_types)
+                                        - device.measurement_bias_vector::<MsrSize>(
+                                            &cur_msr_types,
+                                            epoch,
+                                        )?;
+
                                     match self.kf.measurement_update(
                                         nominal_state,
-                                        &msr.observation(&cur_msr_types),
-                                        &computed_meas.observation(&cur_msr_types),
+                                        &real_obs,
+                                        &computed_obs,
                                         device.measurement_covar_matrix(&cur_msr_types, epoch)?,
                                         self.resid_crit,
                                     ) {

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -26,8 +26,9 @@ pub use crate::od::*;
 use crate::propagators::PropInstance;
 pub use crate::time::{Duration, Unit};
 use anise::prelude::Almanac;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use msr::sensitivity::TrackerSensitivity;
+use msr::MeasurementType;
 use snafu::prelude::*;
 mod conf;
 pub use conf::{IterationConf, SmoothingArc};
@@ -41,7 +42,61 @@ use std::marker::PhantomData;
 use std::ops::Add;
 mod export;
 
-/// An orbit determination process. Note that everything passed to this structure is moved.
+/// Sets up an orbit determination process (ODP).
+///
+/// # Algorithm details
+///
+/// ## Classical vs. Extended Kalman filter
+///
+/// In Nyx, an ODP configured in Classical Kalman Filter will track the state deviation compared to the nominal state.
+/// An ODP configured in Extended Kalman Filter mode will update the propagation state on each (accepted) measurement.
+///
+/// The EKF mode requires a "trigger" which switches the filter from a CKF to an EKF. This prevents quick divergence of a filter.
+///
+/// ## Measurement residual ratio and rejection
+///
+/// The measurement residual is a signed scalar, despite ODP being able to process multiple measurements simultaneously.
+/// By default, if a measurement is more than 3 measurement sigmas off, it will be rejected to avoid biasing the filter.
+///
+/// ## Ambiguity intervals
+///
+/// In the case of ranging, and possibly other data types, a code is used to measure the range to the spacecraft. The length of this code
+/// determines the ambiguity resolution, as per equation 9 in section 2.2.2.2 of the reference. For example, using the JPL Range Code and
+/// a frequency range clock of 1 MHz, the range ambiguity is 75,660 km. In other words, as soon as the spacecraft is at a range of 75,660 + 1 km
+/// the JPL Range Code will report the vehicle to be at a range of 1 km. This is simply because the range code overlaps with itself, effectively
+/// loosing track of its own reference: it's due to the phase shift of the signal "lapping" the original signal length.
+///
+/// ```text
+///             (Spacecraft)
+///             ^
+///             |    Actual Distance = 75,661 km
+///             |
+/// 0 km                                         75,660 km (Wrap-Around)
+/// |-----------------------------------------------|
+///   When the "code length" is exceeded,
+///   measurements wrap back to 0.
+///
+/// So effectively:
+///     Observed code range = Actual range (mod 75,660 km)
+///     75,661 km → 1 km
+///
+/// ```
+///
+/// Nyx solves this problem in two ways: the tracking data must specify a modulus for a specific measurement type. Then, the ambiguity interval
+/// of the ODP must be configured appropriately. In the case of the JPL Range Code and a 1 MHz range clock, the ambiguity interval is 75,660 km.
+/// The ranging equipment will provide a range modulus value, e.g. 123,000 km, which will need to be added to the reported range.
+///
+/// The equipment's modulus is provided in the TDM and must be specified in Nyx's TrackingDataArc `moduli` field.
+/// The ambiguity interval must be specified in the ODP.
+/// The measurement used in the ODP then becomes the following, where `//` represents the [Euclidian division](https://doc.rust-lang.org/std/primitive.f64.html#method.div_euclid).
+///
+/// ```text
+/// k = computed_obs // ambiguity_interval
+/// real_obs = measured_obs + k * modulus
+/// ```
+///
+/// Reference: JPL DESCANSO, document 214, _Pseudo-Noise and Regenerative Ranging_.
+///
 #[allow(clippy::upper_case_acronyms)]
 pub struct ODProcess<
     'a,
@@ -78,6 +133,8 @@ pub struct ODProcess<
     pub ekf_trigger: Option<EkfTrigger>,
     /// Residual rejection criteria allows preventing bad measurements from affecting the estimation.
     pub resid_crit: Option<ResidRejectCrit>,
+    /// Specifies the ambiguity interval of a specific measurement type.
+    pub ambiguity_intervals: Option<IndexMap<MeasurementType, f64>>,
     pub almanac: Arc<Almanac>,
     init_state: D::StateType,
     _marker: PhantomData<Accel>,
@@ -124,6 +181,7 @@ where
             residuals: Vec::with_capacity(10_000),
             ekf_trigger,
             resid_crit,
+            ambiguity_intervals: None,
             almanac,
             init_state,
             _marker: PhantomData::<Accel>,
@@ -148,6 +206,7 @@ where
             residuals: Vec::with_capacity(10_000),
             ekf_trigger: Some(trigger),
             resid_crit,
+            ambiguity_intervals: None,
             almanac,
             init_state,
             _marker: PhantomData::<Accel>,
@@ -560,14 +619,38 @@ where
 
                                     self.kf.update_h_tilde(h_tilde);
 
-                                    let real_obs = msr.observation(&cur_msr_types);
-
                                     let computed_obs = computed_meas
                                         .observation::<MsrSize>(&cur_msr_types)
                                         - device.measurement_bias_vector::<MsrSize>(
                                             &cur_msr_types,
                                             epoch,
                                         )?;
+
+                                    let mut real_obs = msr.observation(&cur_msr_types);
+
+                                    // If there is an ambiguity, apply it.
+                                    if let Some(ambiguity) = &self.ambiguity_intervals {
+                                        // Rebuild the R matrix of the measurement noise.
+                                        let mut obs_ambiguity = OVector::<f64, MsrSize>::zeros();
+
+                                        for (i, msr_type) in cur_msr_types.iter().enumerate() {
+                                            if let Some(interval) = ambiguity.get(msr_type) {
+                                                if let Some(moduli) = &arc.moduli {
+                                                    if let Some(modulus) = moduli.get(msr_type) {
+                                                        let k =
+                                                            computed_obs[i].div_euclid(*interval);
+                                                        // real_obs = measured_obs + k * modulus
+                                                        obs_ambiguity[i] = k * *modulus;
+                                                    }
+                                                } else {
+                                                    // No need to account for ambiguity intervals if there is no moduli configured.
+                                                    break;
+                                                }
+                                            }
+                                        }
+
+                                        real_obs += obs_ambiguity;
+                                    }
 
                                     match self.kf.measurement_update(
                                         nominal_state,
@@ -784,6 +867,7 @@ where
             resid_crit,
             ekf_trigger: None,
             init_state,
+            ambiguity_intervals: None,
             almanac,
             _marker: PhantomData::<Accel>,
         }

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -595,9 +595,6 @@ where
                                             }
                                         }
                                         real_obs += obs_ambiguity;
-                                    } else {
-                                        // No need to account for ambiguity intervals if there is no moduli configured.
-                                        break;
                                     }
 
                                     match self.kf.measurement_update(

--- a/src/od/process/trigger.rs
+++ b/src/od/process/trigger.rs
@@ -23,8 +23,9 @@ use crate::linalg::allocator::Allocator;
 use crate::linalg::DefaultAllocator;
 use crate::time::Duration;
 use crate::State;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Default, Deserialize)]
 /// An EkfTrigger on the number of measurements processed and a time between measurements.
 pub struct EkfTrigger {
     pub num_msrs: usize,

--- a/src/od/simulator/arc.rs
+++ b/src/od/simulator/arc.rs
@@ -237,6 +237,7 @@ where
         let trk_data = TrackingDataArc {
             measurements,
             source: None,
+            moduli: None,
         };
 
         Ok(trk_data)

--- a/src/propagators/mod.rs
+++ b/src/propagators/mod.rs
@@ -32,12 +32,12 @@ pub use propagator::*;
 mod rk_methods;
 pub use rk_methods::*;
 mod options;
-pub use options::*;
-
 use crate::{dynamics::DynamicsError, errors::EventError, io::ConfigError, time::Duration};
+pub use options::*;
+use serde::{Deserialize, Serialize};
 
 /// Stores the details of the previous integration step of a given propagator. Access as `my_prop.clone().latest_details()`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct IntegrationDetails {
     /// step size used
     pub step: Duration,

--- a/tests/orbit_determination/simulator.rs
+++ b/tests/orbit_determination/simulator.rs
@@ -245,8 +245,6 @@ fn od_with_modulus_cov_test(
     assert!((uncertainty.vy_km_s - 0.5e-3).abs() < f64::EPSILON);
     assert!((uncertainty.vz_km_s - 0.5e-3).abs() < f64::EPSILON);
 
-    println!("{uncertainty}");
-
     let estimate = uncertainty.to_estimate().unwrap();
 
     println!("{estimate}");
@@ -341,7 +339,9 @@ fn od_with_modulus_as_bias_cov_test(
 
     let estimate = uncertainty.to_estimate().unwrap();
 
-    let kf = KF::no_snc(estimate);
+    let sigma_q = 1e-8_f64.powi(2);
+    let process_noise = SNC3::from_diagonal(2 * Unit::Minute, &[sigma_q, sigma_q, sigma_q]);
+    let kf = KF::new(estimate, process_noise);
 
     let setup = Propagator::default(SpacecraftDynamics::new(OrbitalDynamics::two_body()));
     let prop = setup.with(spacecraft.with_stm(), almanac.clone());

--- a/tests/orbit_determination/simulator.rs
+++ b/tests/orbit_determination/simulator.rs
@@ -257,7 +257,9 @@ fn od_with_modulus_cov_test(
 
     println!("{estimate}");
 
-    let kf = KF::no_snc(estimate);
+    let sigma_q = 1e-12_f64.powi(2);
+    let process_noise = SNC3::from_diagonal(2 * Unit::Minute, &[sigma_q, sigma_q, sigma_q]);
+    let kf = KF::new(estimate, process_noise);
 
     let setup = Propagator::default(SpacecraftDynamics::new(OrbitalDynamics::two_body()));
     let prop = setup.with(spacecraft.with_stm(), almanac.clone());

--- a/tests/orbit_determination/simulator.rs
+++ b/tests/orbit_determination/simulator.rs
@@ -216,7 +216,7 @@ fn continuous_tracking_cov_test(tracking_data: TrackingDataArc) {
 fn od_with_modulus_cov_test(
     spacecraft: Spacecraft,
     tracking_data: TrackingDataArc,
-    devices: BTreeMap<String, GroundStation>,
+    mut devices: BTreeMap<String, GroundStation>,
     trajectory: Trajectory,
     almanac: Arc<Almanac>,
 ) {
@@ -226,6 +226,14 @@ fn od_with_modulus_cov_test(
     let jpl_dsn_code_length_km = 75660.0;
     arc.set_moduli(MeasurementType::Range, jpl_dsn_code_length_km);
     arc.apply_moduli();
+
+    // Increase the noise on the OD process
+    // Set a bias instead of assuming a modulus.
+    for (_, device) in &mut devices {
+        for (_, stochastics) in device.stochastic_noises.as_mut().unwrap().iter_mut() {
+            *stochastics *= 2.0;
+        }
+    }
 
     let uncertainty = SpacecraftUncertainty::builder()
         .nominal(spacecraft)

--- a/tests/orbit_determination/simulator.rs
+++ b/tests/orbit_determination/simulator.rs
@@ -164,6 +164,11 @@ fn continuous_tracking_cov_test(almanac: Arc<Almanac>) {
     assert_eq!(arc_tdm.start_epoch(), arc.start_epoch());
     assert_eq!(arc_tdm.end_epoch(), arc.end_epoch());
     assert_eq!(arc_tdm.unique(), arc.unique());
+    // Check that we have multiplied back and divided back correctly.
+    for (epoch, orig_msr) in &arc.measurements {
+        assert_eq!(orig_msr, (&arc_tdm).measurements.get(epoch).unwrap());
+    }
+    assert_eq!(arc_tdm.measurements, arc.measurements);
 
     // Test the downsampling
     let tdm_failed_downsample = arc_tdm.clone().downsample(0.1.seconds());


### PR DESCRIPTION
# Summary

- Support ambiguity resolution as per JPL DESCANSO [214 - Pseudo-Noise and regenerative ranging](https://deepspace.jpl.nasa.gov/dsndocs/810-005/214/214C.pdf)
- Support moduli as per CCSDS TDM Blue Book
- Fix path in Nyx-built TDMs, accounting for whether the measurement type is one or two way, fixes #397 
- Add serde for (most) every input, outputs (like event evaluations) should still go in parquet, fixes #396 

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

- Add moduli to tracking data arc
- Add optional constant to stochastic models

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

- Accounts for ambiguity resolution / modulus in orbit determination

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

- Fix TDM parsing for two-way measurements

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

As per #397 :
Simulate a tracking arc with the JPL DSN Code whose modulus is 75660 km. To ensure testing of the ambiguity intervals, fix the `apply_moduli` function to account for that ambiguity. Then, build two tests:

- [x] Solve the OD with a properly configured moduli
- [x] Solve the OD with a constant bias

Measurements for reference (2x):
![image](https://github.com/user-attachments/assets/1dd63989-6d55-459e-8106-f71777fc94c2)

So we see that nearly from the start of the arc, we're already at factor of 2x the JPL code. The comforts the properly configured moduli test.

### Solving with properly configured moduli

_No tuning done at all_

The results without any tuning look reasonable, especially in the range component where we've put a full 75 Mm ambiguity from the JPL DSN code.

![image](https://github.com/user-attachments/assets/12e5f702-de3e-4126-afc5-330ba5ec1777)


### Solving with a constant bias

_No tuning done at all_

We see step function residuals and ratios on range around the time the range measurement is > 2x the JPL code ambiguity, causing the filter to rely on Doppler instead.

![image](https://github.com/user-attachments/assets/ea111916-8174-472f-807b-cc8b6e188457)

![image](https://github.com/user-attachments/assets/97319bf3-af4a-4100-98d5-20b2a28d88b0)




## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

Greatly expanded ODProcess documentation.

<!-- Thank you for contributing to Nyx! -->