### PR TITLE
Fix zero measurement observation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nyx-space"
 build = "build.rs"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "A high-fidelity space mission toolkit, with orbit propagation, estimation and some systems engineering"

--- a/src/od/estimate/residual.rs
+++ b/src/od/estimate/residual.rs
@@ -48,6 +48,10 @@ where
     pub tracker: Option<String>,
     /// Measurement types used to compute this residual (in order)
     pub msr_types: IndexSet<MeasurementType>,
+    /// The real observation from the tracking arc.
+    pub real_obs: OVector<f64, M>,
+    /// The computed observation as expected from the dynamics of the filter.
+    pub computed_obs: OVector<f64, M>,
 }
 
 impl<M> Residual<M>
@@ -66,6 +70,8 @@ where
             rejected: true,
             tracker: None,
             msr_types: IndexSet::new(),
+            real_obs: OVector::<f64, M>::zeros(),
+            computed_obs: OVector::<f64, M>::zeros(),
         }
     }
 
@@ -75,6 +81,8 @@ where
         prefit: OVector<f64, M>,
         ratio: f64,
         tracker_msr_covar: OVector<f64, M>,
+        real_obs: OVector<f64, M>,
+        computed_obs: OVector<f64, M>,
     ) -> Self {
         Self {
             epoch,
@@ -85,6 +93,8 @@ where
             rejected: true,
             tracker: None,
             msr_types: IndexSet::new(),
+            real_obs,
+            computed_obs,
         }
     }
 
@@ -94,6 +104,8 @@ where
         postfit: OVector<f64, M>,
         ratio: f64,
         tracker_msr_covar: OVector<f64, M>,
+        real_obs: OVector<f64, M>,
+        computed_obs: OVector<f64, M>,
     ) -> Self {
         Self {
             epoch,
@@ -104,6 +116,8 @@ where
             rejected: false,
             tracker: None,
             msr_types: IndexSet::new(),
+            real_obs,
+            computed_obs,
         }
     }
 
@@ -126,6 +140,20 @@ where
         self.msr_types
             .get_index_of(&msr_type)
             .map(|idx| self.tracker_msr_noise[idx])
+    }
+
+    /// Returns the real observation for this measurement type, if available
+    pub fn real_obs(&self, msr_type: MeasurementType) -> Option<f64> {
+        self.msr_types
+            .get_index_of(&msr_type)
+            .map(|idx| self.real_obs[idx])
+    }
+
+    /// Returns the computed/expected observation for this measurement type, if available
+    pub fn computed_obs(&self, msr_type: MeasurementType) -> Option<f64> {
+        self.msr_types
+            .get_index_of(&msr_type)
+            .map(|idx| self.computed_obs[idx])
     }
 }
 

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -274,8 +274,8 @@ where
     fn measurement_update(
         &mut self,
         nominal_state: T,
-        real_obs: &OVector<f64, M>,
-        computed_obs: &OVector<f64, M>,
+        real_obs: OVector<f64, M>,
+        computed_obs: OVector<f64, M>,
         r_k: OMatrix<f64, M, M>,
         resid_rejection: Option<ResidRejectCrit>,
     ) -> Result<(Self::Estimate, Residual<M>), ODError> {
@@ -298,7 +298,7 @@ where
         let s_k = &h_p_ht + &r_k;
 
         // Compute observation deviation/error (usually marked as y_i)
-        let prefit = real_obs - computed_obs;
+        let prefit = real_obs.clone() - computed_obs.clone();
 
         // Compute the prefit ratio for the automatic rejection.
         // The measurement covariance is the square of the measurement itself.
@@ -329,7 +329,14 @@ where
                 let pred_est = self.time_update(nominal_state)?;
                 return Ok((
                     pred_est,
-                    Residual::rejected(epoch, prefit, ratio, r_k_chol.diagonal()),
+                    Residual::rejected(
+                        epoch,
+                        prefit,
+                        ratio,
+                        r_k_chol.diagonal(),
+                        real_obs,
+                        computed_obs,
+                    ),
                 ));
             }
         }

--- a/src/od/filter/kalman.rs
+++ b/src/od/filter/kalman.rs
@@ -350,7 +350,15 @@ where
             let postfit = &prefit - (&self.h_tilde * state_hat);
             (
                 state_hat,
-                Residual::accepted(epoch, prefit, postfit, ratio, r_k_chol.diagonal()),
+                Residual::accepted(
+                    epoch,
+                    prefit,
+                    postfit,
+                    ratio,
+                    r_k_chol.diagonal(),
+                    real_obs,
+                    computed_obs,
+                ),
             )
         } else {
             // Time update
@@ -358,7 +366,15 @@ where
             let postfit = &prefit - (&self.h_tilde * state_bar);
             (
                 state_bar + &gain * &postfit,
-                Residual::accepted(epoch, prefit, postfit, ratio, r_k_chol.diagonal()),
+                Residual::accepted(
+                    epoch,
+                    prefit,
+                    postfit,
+                    ratio,
+                    r_k_chol.diagonal(),
+                    real_obs,
+                    computed_obs,
+                ),
             )
         };
 

--- a/src/od/filter/mod.rs
+++ b/src/od/filter/mod.rs
@@ -80,8 +80,8 @@ where
     fn measurement_update(
         &mut self,
         nominal_state: T,
-        real_obs: &OVector<f64, M>,
-        computed_obs: &OVector<f64, M>,
+        real_obs: OVector<f64, M>,
+        computed_obs: OVector<f64, M>,
         measurement_covar: OMatrix<f64, M, M>,
         resid_rejection: Option<ResidRejectCrit>,
     ) -> Result<(Self::Estimate, Residual<M>), ODError>;

--- a/src/od/process/export.rs
+++ b/src/od/process/export.rs
@@ -238,6 +238,20 @@ where
                     .with_name(format!("Measurement noise: {f:?} ({})", f.unit())),
             );
         }
+        for f in arc.unique_types() {
+            msr_fields.push(
+                f.to_field()
+                    .with_nullable(true)
+                    .with_name(format!("Real observation: {f:?} ({})", f.unit())),
+            );
+        }
+        for f in arc.unique_types() {
+            msr_fields.push(
+                f.to_field()
+                    .with_nullable(true)
+                    .with_name(format!("Computed observation: {f:?} ({})", f.unit())),
+            );
+        }
 
         msr_fields.push(Field::new("Residual ratio", DataType::Float64, true));
         msr_fields.push(Field::new("Residual Rejected", DataType::Boolean, true));
@@ -394,6 +408,36 @@ where
                 if let Some(resid) = resid_opt {
                     match resid.trk_noise(msr_type) {
                         Some(noise) => data.append_value(noise),
+                        None => data.append_null(),
+                    };
+                } else {
+                    data.append_null();
+                }
+            }
+            record.push(Arc::new(data.finish()));
+        }
+        // Real observation
+        for msr_type in arc.unique_types() {
+            let mut data = Float64Builder::new();
+            for resid_opt in &residuals {
+                if let Some(resid) = resid_opt {
+                    match resid.real_obs(msr_type) {
+                        Some(postfit) => data.append_value(postfit),
+                        None => data.append_null(),
+                    };
+                } else {
+                    data.append_null();
+                }
+            }
+            record.push(Arc::new(data.finish()));
+        }
+        // Computed observation
+        for msr_type in arc.unique_types() {
+            let mut data = Float64Builder::new();
+            for resid_opt in &residuals {
+                if let Some(resid) = resid_opt {
+                    match resid.computed_obs(msr_type) {
+                        Some(postfit) => data.append_value(postfit),
                         None => data.append_null(),
                     };
                 } else {

--- a/src/od/process/mod.rs
+++ b/src/od/process/mod.rs
@@ -616,12 +616,6 @@ where
                                         real_obs += obs_ambiguity;
                                     }
 
-                                    if real_obs.norm() == 0.0 {
-                                        // Prevent bug in data type selection of ground station.
-                                        // https://github.com/nyx-space/nyx/issues/410
-                                        panic!("not fixed");
-                                    }
-
                                     match self.kf.measurement_update(
                                         nominal_state,
                                         real_obs,

--- a/tests/orbit_determination/mod.rs
+++ b/tests/orbit_determination/mod.rs
@@ -45,8 +45,8 @@ fn empty_estimate() {
 fn filter_errors() {
     let initial_estimate = KfEstimate::zeros(Spacecraft::zeros());
     let measurement_noise = Matrix2::zeros();
-    let real_obs = &Vector2::zeros();
-    let computed_obs = &Vector2::zeros();
+    let real_obs = Vector2::zeros();
+    let computed_obs = Vector2::zeros();
     let sensitivity = SMatrix::<f64, 2, 9>::zeros();
 
     let mut ckf = KF::no_snc(initial_estimate);


### PR DESCRIPTION
# Summary

**Breaking changes:**
1. `measurement_update` now owns the real and computed observations
2. Residual now include a copy of the real and computed observations, enabling all runs to also plot the residual versus reference when disabling measurements from a specific arc.

Also fixes a zero norm measurement when such measurement is not available in the tracker but is available in the measurement data.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

1. `measurement_update` now owns the real and computed observations -- this enables the following item
2. Residual now include a copy of the real and computed observations.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

Residual now include a copy of the real and computed observations, enabling all runs to also plot the residual versus reference when disabling measurements from a specific arc.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes 

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

Fix #410

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

**Detail the changes in tests, including new tests and validations**

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->