### PR TITLE
Fix/event heuristic gh 440

### DIFF
--- a/src/mc/results.rs
+++ b/src/mc/results.rs
@@ -317,12 +317,15 @@ where
 
         let more_meta = Some(vec![(
             "Frame".to_string(),
-            serde_dhall::serialize(&frame).to_string().map_err(|e| {
-                Box::new(InputOutputError::SerializeDhall {
-                    what: format!("frame `{frame}`"),
-                    err: e.to_string(),
-                })
-            })?,
+            serde_dhall::serialize(&frame)
+                .static_type_annotation()
+                .to_string()
+                .map_err(|e| {
+                    Box::new(InputOutputError::SerializeDhall {
+                        what: format!("frame `{frame}`"),
+                        err: e.to_string(),
+                    })
+                })?,
         )]);
 
         for field in &fields {

--- a/src/md/events/details.rs
+++ b/src/md/events/details.rs
@@ -110,7 +110,7 @@ where
                 } else if prev_value < value && value < next_value {
                     EventEdge::Rising
                 } else {
-                    warn!("could not determine edge of {} at {}", event, state.epoch(),);
+                    debug!("could not determine edge of {} at {}", event, state.epoch(),);
                     EventEdge::Unclear
                 }
             } else if prev_value > value {

--- a/src/md/opti/multipleshooting/altitude_heuristic.rs
+++ b/src/md/opti/multipleshooting/altitude_heuristic.rs
@@ -48,7 +48,7 @@ impl<'a> MultipleShooting<'a, Node, 3, 3> {
             error!("At least three nodes are needed for a multiple shooting optimization");
             return Err(MultipleShootingError::TargetingError {
                 segment: 0_usize,
-                source: TargetingError::UnderdeterminedProblem,
+                source: Box::new(TargetingError::UnderdeterminedProblem),
             });
         }
 

--- a/src/md/opti/multipleshooting/mod.rs
+++ b/src/md/opti/multipleshooting/mod.rs
@@ -40,7 +40,8 @@ pub enum MultipleShootingError {
     #[snafu(display("segment #{segment} encountered {source}"))]
     TargetingError {
         segment: usize,
-        source: TargetingError,
+        #[snafu(source(from(TargetingError, Box::new)))]
+        source: Box<TargetingError>,
     },
     #[snafu(display("during a multiple shooting, encountered {source}"))]
     MultiShootTrajError { source: TrajError },

--- a/src/md/opti/multipleshooting/multishoot.rs
+++ b/src/md/opti/multipleshooting/multishoot.rs
@@ -273,7 +273,7 @@ impl<T: MultishootNode<OT>, const VT: usize, const OT: usize> MultipleShooting<'
         }
         Err(MultipleShootingError::TargetingError {
             segment: 0_usize,
-            source: TargetingError::TooManyIterations,
+            source: Box::new(TargetingError::TooManyIterations),
         })
     }
 }

--- a/src/md/trajectory/traj.rs
+++ b/src/md/trajectory/traj.rs
@@ -206,12 +206,15 @@ where
         let frame = self.states[0].frame();
         let more_meta = Some(vec![(
             "Frame".to_string(),
-            serde_dhall::serialize(&frame).to_string().map_err(|e| {
-                Box::new(InputOutputError::SerializeDhall {
-                    what: format!("frame `{frame}`"),
-                    err: e.to_string(),
-                })
-            })?,
+            serde_dhall::serialize(&frame)
+                .static_type_annotation()
+                .to_string()
+                .map_err(|e| {
+                    Box::new(InputOutputError::SerializeDhall {
+                        what: format!("frame `{frame}`"),
+                        err: e.to_string(),
+                    })
+                })?,
         )]);
 
         let mut fields = match cfg.fields {
@@ -415,6 +418,7 @@ where
         let more_meta = Some(vec![(
             "Frame".to_string(),
             serde_dhall::serialize(&frame)
+                .static_type_annotation()
                 .to_string()
                 .unwrap_or(frame.to_string()),
         )]);

--- a/src/od/process/solution/export.rs
+++ b/src/od/process/solution/export.rs
@@ -119,6 +119,7 @@ where
             (
                 "Frame".to_string(),
                 serde_dhall::serialize(&frame)
+                    .static_type_annotation()
                     .to_string()
                     .map_err(|e| ODError::ODIOError {
                         source: InputOutputError::SerializeDhall {

--- a/src/od/simulator/arc.rs
+++ b/src/od/simulator/arc.rs
@@ -299,7 +299,7 @@ impl TrackingArcSim<Spacecraft, GroundStation> {
                     // Convert the trajectory into the ground station frame.
                     let traj = self.trajectory.to_frame(device.frame, almanac.clone())?;
 
-                    match traj.find_arcs(&device, almanac.clone()) {
+                    match traj.find_arcs(&device, None, almanac.clone()) {
                         Err(_) => info!("No measurements from {name}"),
                         Ok(elevation_arcs) => {
                             for arc in elevation_arcs {

--- a/src/propagators/instance.rs
+++ b/src/propagators/instance.rs
@@ -352,7 +352,7 @@ where
         let (_, traj) = self.for_duration_with_traj(max_duration)?;
         // Now, find the requested event
         let events = traj
-            .find(event, self.almanac.clone())
+            .find(event, None, self.almanac.clone())
             .context(TrajectoryEventSnafu)?;
         match events.get(trigger) {
             Some(event_state) => Ok((event_state.state, traj)),

--- a/tests/orbit_determination/multi_body.rs
+++ b/tests/orbit_determination/multi_body.rs
@@ -331,7 +331,7 @@ fn multi_body_ckf_covar_map_cov_test(
     // Test that we can generate a navigation trajectory and search it
     let nav_traj = od_sol.to_traj().unwrap();
     let aop_event = Event::apoapsis();
-    for found_event in nav_traj.find(&aop_event, almanac).unwrap() {
+    for found_event in nav_traj.find(&aop_event, None, almanac).unwrap() {
         println!("{:x}", found_event.state);
         assert!((found_event.state.orbit.ta_deg().unwrap() - 180.0).abs() < 1e-2)
     }

--- a/tests/propagation/stopcond.rs
+++ b/tests/propagation/stopcond.rs
@@ -47,7 +47,7 @@ fn stop_cond_3rd_apo_cov_test(almanac: Arc<Almanac>) {
     // NOTE: We start counting at ZERO, so finding the 3rd means grabbing the second found.
     let (third_apo, traj) = prop.until_nth_event(5 * period, &apo_event, 2).unwrap();
 
-    let events = traj.find(&apo_event, almanac).unwrap();
+    let events = traj.find(&apo_event, None, almanac).unwrap();
     let mut prev_event_match = events[0].state.epoch();
     for event_match in events.iter().skip(1) {
         let delta_period = event_match.state.epoch() - prev_event_match - period;
@@ -99,7 +99,7 @@ fn stop_cond_3rd_peri(almanac: Arc<Almanac>) {
     // which the event finder will find.
     let (third_peri, traj) = prop.until_nth_event(5 * period, &peri_event, 2).unwrap();
 
-    let events = traj.find(&peri_event, almanac).unwrap();
+    let events = traj.find(&peri_event, None, almanac).unwrap();
     let mut prev_event_match = events[0].state.epoch();
     for event_match in events.iter().skip(1) {
         let delta_period = event_match.state.epoch() - prev_event_match - period;
@@ -202,7 +202,7 @@ fn stop_cond_nrho_apo(almanac: Arc<Almanac>) {
     );
 
     // Now, find all of the requested events
-    let events = traj_luna.find(&near_apo_event, almanac).unwrap();
+    let events = traj_luna.find(&near_apo_event, None, almanac).unwrap();
     println!(
         "Found all {} events in {} ms",
         near_apo_event,
@@ -363,7 +363,7 @@ fn event_and_combination(almanac: Arc<Almanac>) {
     // NOTE: We're unwrapping here, so if the event isn't found, this will cause the test to fail.
     let event = Event::specific(StateParameter::Declination, 6.0, 3.0, Unit::Minute);
     let mut decl_deg = 0.0;
-    if let Ok(matching_states) = traj_moon.find(&event, almanac.clone()) {
+    if let Ok(matching_states) = traj_moon.find(&event, None, almanac.clone()) {
         for sc_decl_zero in matching_states {
             decl_deg = sc_decl_zero
                 .state
@@ -376,6 +376,7 @@ fn event_and_combination(almanac: Arc<Almanac>) {
         // We should be able to find a similar event with a tighter bound too.
         if let Ok(tighter_states) = traj_moon.find(
             &Event::specific(StateParameter::Declination, decl_deg, 1.0, Unit::Minute),
+            None,
             almanac,
         ) {
             for sc_decl_zero in tighter_states {

--- a/tests/propulsion/closedloop_multi_oe_ruggiero.rs
+++ b/tests/propulsion/closedloop_multi_oe_ruggiero.rs
@@ -81,7 +81,7 @@ fn qlaw_as_ruggiero_case_a(almanac: Arc<Almanac>) {
     for e in &events {
         println!(
             "[qlaw_as_ruggiero_case_a] Found {} events of kind {}",
-            traj.find(e, almanac.clone()).unwrap().len(),
+            traj.find(e, None, almanac.clone()).unwrap().len(),
             e
         );
     }

--- a/tests/propulsion/closedloop_single_oe_ruggiero.rs
+++ b/tests/propulsion/closedloop_single_oe_ruggiero.rs
@@ -698,7 +698,11 @@ fn rugg_raan(almanac: Arc<Almanac>) {
     let prop_usage = prop_mass - final_state.mass.prop_mass_kg;
     println!("[rugg_raan] {:x}", final_state.orbit);
     let event = Event::new(StateParameter::RAAN, 5.0);
-    println!("[rugg_raan] {} => {:?}", event, traj.find(&event, almanac));
+    println!(
+        "[rugg_raan] {} => {:?}",
+        event,
+        traj.find(&event, None, almanac)
+    );
     println!("[rugg_raan] prop usage: {prop_usage:.3} kg");
 
     assert!(


### PR DESCRIPTION
# Summary

Add a new `heuristic: Option<Duration>` to event finders on the trajectory. Moved the TargetingError to a Box because it was larger than 128 octets.

Fix #440 

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

- Event searching can now use a custom heuristic instead of the 1% of trajectory duration. This is useful for very long trajectories.

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

The event tracker true anomaly test was extended to propagate for 200 orbits and the test now checks that the correct number of true anomaly events is found. A 1% heuristic would miss half of these.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->