### PR TITLE
Add link specific orbit determination noise modeling (premium feature) + validate existing noise modeling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ polars = { version = "0.49.0", features = ["parquet"] }
 rstest = "0.26.1"
 pretty_env_logger = "0.5"
 toml = "0.9.0"
+serde_arrow = {version = "0.13", features = ["arrow-55"]}
 
 [build-dependencies]
 shadow-rs = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ serde_dhall = "0.12"
 indexmap = { version = "2.6.0", features = ["serde"] }
 statrs = "0.18.0"
 
+[features]
+default = ["premium"]
+# Premium feature is NOT available to most commercial entities. Refer to the README.
+premium = []
 
 [dev-dependencies]
 polars = { version = "0.49.0", features = ["parquet"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ Nyx is revolutionizing the field of flight dynamics engineering as a powerful, o
 [![nyx-space on docs.rs][docsrs-image]][docsrs]
 [![codecov](https://codecov.io/gh/nyx-space/nyx/graph/badge.svg?token=gEiAvwzwh5)](https://codecov.io/gh/nyx-space/nyx)
 
+# License
+
+The core of Nyx is provided under the [AGPLv3 License](./LICENSE). We are committed to keeping the foundational components of Nyx open-source and accessible to everyone.
+
+By using this software, you assume responsibility for adhering to the license.
+
+Refer to [the pricing page](https://nyxspace.com/pricing/?utm_source=readme-price) for an FAQ on the AGPLv3 license.
+Notably, any software that incorporates, links to, or depends on Nyx must also be released under the AGPLv3 license, even if you distribute an unmodified version of Nyx.
+
+
+Starting with version `2.2.0-alpha`, Nyx now offers a set of advanced functionalities available under a `premium` crate feature. This feature operates under a **dual-license** model.
+
+## The `premium` Feature License
+
+The `premium` feature is available for use free of charge under the standard AGPLv3 license for the following users:
+* Individuals
+* Non-profit organizations
+* Academic institutions
+* Commercial entities with annual gross revenue of **$1,000,000 USD** (one million) or less.
+
+Use of any code enabled by the `premium` feature is **prohibited** for any for-profit entity (including, but not limited to, companies, corporations, and organizations) whose annual gross revenue exceeds **$1,000,000 USD**.
+
+The revenue threshold of $1,000,000 USD is indexed to the official U.S. inflation rate, with the year 2025 serving as the baseline. The threshold will be adjusted annually to account for inflation.
+
+_Note:_ under the assumption that most users are below this threshold, the `premium` feature is enabled _by default_. As a user **you are responsible** for ensuring compliance with the license by your entity and customers. It is enforced.
+
+### Commercial Use
+
+Entities exceeding this revenue threshold **must purchase a commercial license** to enable and use the `premium` feature. This license grants you the right to use these advanced features in your commercial products and services.
+
+To inquire about a commercial license, please contact me at **[christopher.rabotin@gmail.com]** or via the [contact form][contact].
+
 # Showcase
 
 [The website has the latest use cases][showcase]
@@ -57,10 +89,6 @@ Nyx uses `lld`, the LLVM linker, for faster compilation times. You may need to m
 For Python projects, get started by installing the library via `pip`: `pip install nyx_space`.
 
 **Important:** The Python package has been temporarily disabled. Refer to <https://github.com/nyx-space/nyx/issues/311> for details.
-
-# License
-
-Nyx is provided under the [AGPLv3 License](./LICENSE). By using this software, you assume responsibility for adhering to the license. Refer to [the pricing page](https://nyxspace.com/pricing/?utm_source=readme-price) for an FAQ on the AGPLv3 license. Notably, any software that incorporates, links to, or depends on Nyx must also be released under the AGPLv3 license, even if you distribute an unmodified version of Nyx.
 
 # Versioning
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Nyx is revolutionizing the field of flight dynamics engineering as a powerful, open-source tool for mission design and orbit determination. From trajectory optimization to orbit estimation, Nyx is built for speed, automation, and scalability.
 
-**Nyx has proven mission-critical reliability, already contributing to the success of three lunar missions.**
+**Nyx has proven mission-critical reliability, already contributing to the success of several lunar missions including Firefly Blue Ghost 1 and NASA/Adanced Space CAPSTONE.**
 
 [![Nyx Space Badget][nyxspace-image]][website]
 [![Contact Form][contact-form-image]][contact]
@@ -15,13 +15,9 @@ Nyx is revolutionizing the field of flight dynamics engineering as a powerful, o
 
 # License
 
-The core of Nyx is provided under the [AGPLv3 License](./LICENSE). We are committed to keeping the foundational components of Nyx open-source and accessible to everyone.
+The core of Nyx is provided under the [AGPLv3 License](./LICENSE). The foundational components of Nyx are open-source and accessible to everyone.
 
-By using this software, you assume responsibility for adhering to the license.
-
-Refer to [the pricing page](https://nyxspace.com/pricing/?utm_source=readme-price) for an FAQ on the AGPLv3 license.
-Notably, any software that incorporates, links to, or depends on Nyx must also be released under the AGPLv3 license, even if you distribute an unmodified version of Nyx.
-
+By using this software, you assume responsibility for adhering to the license. Refer to [the pricing page](https://nyxspace.com/pricing/?utm_source=readme-price) for an FAQ on the AGPLv3 license. Notably, any software that incorporates, links to, or depends on Nyx must also be released under the AGPLv3 license, even if you distribute an unmodified version of Nyx.
 
 Starting with version `2.2.0-alpha`, Nyx now offers a set of advanced functionalities available under a `premium` crate feature. This feature operates under a **dual-license** model.
 
@@ -34,16 +30,10 @@ The `premium` feature is available for use free of charge under the standard AGP
 * Commercial entities with annual gross revenue of **$1,000,000 USD** (one million) or less.
 
 Use of any code enabled by the `premium` feature is **prohibited** for any for-profit entity (including, but not limited to, companies, corporations, and organizations) whose annual gross revenue exceeds **$1,000,000 USD**.
-
-The revenue threshold of $1,000,000 USD is indexed to the official U.S. inflation rate, with the year 2025 serving as the baseline. The threshold will be adjusted annually to account for inflation.
+Entities exceeding this revenue threshold **must purchase a commercial license** to enable and use the `premium` feature. This license grants you the right to use these advanced features in your commercial products and services.
+To inquire about a commercial license, please contact me at **christopher.rabotin@gmail.com** or via the [contact form][contact].
 
 _Note:_ under the assumption that most users are below this threshold, the `premium` feature is enabled _by default_. As a user **you are responsible** for ensuring compliance with the license by your entity and customers. It is enforced.
-
-### Commercial Use
-
-Entities exceeding this revenue threshold **must purchase a commercial license** to enable and use the `premium` feature. This license grants you the right to use these advanced features in your commercial products and services.
-
-To inquire about a commercial license, please contact me at **[christopher.rabotin@gmail.com]** or via the [contact form][contact].
 
 # Showcase
 
@@ -111,7 +101,7 @@ Major releases are for dramatic changes.
 
 > Chris Rabotin is a GNC and flight dynamics engineer with a heavy background in software.
 
-I currently work for Rocket Lab USA as the lead flight dynamics engineer on both Blue Ghost lunar lander missions. -- Find me on [LinkedIn](https://www.linkedin.com/in/chrisrabotin/).
+I currently work for Rocket Lab USA as the lead flight dynamics engineer on the Blue Ghost lunar lander missions. -- Find me on [LinkedIn](https://www.linkedin.com/in/chrisrabotin/).
 
 # External contributions
 

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -219,6 +219,19 @@ impl TrackingDataArc {
         self
     }
 
+    /// Returns a new tracking arc that only contains measurements of the provided type.
+    pub fn filter_by_measurement_type(mut self, included_type: MeasurementType) -> Self {
+        self.measurements = self
+            .measurements
+            .iter_mut()
+            .map(|(epoch, msr)| {
+                msr.data.retain(|msr_type, _| *msr_type == included_type);
+
+                (*epoch, msr.clone())
+            })
+            .collect::<BTreeMap<Epoch, Measurement>>();
+        self
+    }
     /// Returns a new tracking arc that contains measurements from all trackers except the one provided
     pub fn exclude_tracker(mut self, excluded_tracker: String) -> Self {
         self.measurements = self

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -221,17 +221,13 @@ impl TrackingDataArc {
 
     /// Returns a new tracking arc that only contains measurements of the provided type.
     pub fn filter_by_measurement_type(mut self, included_type: MeasurementType) -> Self {
-        self.measurements = self
-            .measurements
-            .iter_mut()
-            .map(|(epoch, msr)| {
-                msr.data.retain(|msr_type, _| *msr_type == included_type);
-
-                (*epoch, msr.clone())
-            })
-            .collect::<BTreeMap<Epoch, Measurement>>();
+        self.measurements.retain(|_epoch, msr| {
+            msr.data.retain(|msr_type, _| *msr_type == included_type);
+            !msr.data.is_empty()
+        });
         self
     }
+
     /// Returns a new tracking arc that contains measurements from all trackers except the one provided
     pub fn exclude_tracker(mut self, excluded_tracker: String) -> Self {
         self.measurements = self

--- a/src/od/noise/link_specific.rs
+++ b/src/od/noise/link_specific.rs
@@ -1,0 +1,232 @@
+/*
+    Nyx, blazing fast astrodynamics
+    Copyright (C) 2018-onwards Christopher Rabotin <christopher.rabotin@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use super::{StochasticNoise, WhiteNoise};
+use anise::constants::SPEED_OF_LIGHT_KM_S;
+use hifitime::Duration;
+use serde_derive::{Deserialize, Serialize};
+use std::f64::consts::TAU;
+
+/// Signal power to noise density for stochastic modeling, typical values.
+/// IMPORTANT: The S/N0 will always be lower or equal to the Carrier Power to noise density (C/N0)
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum SN0 {
+    /// 65 dB-Hz
+    Strong,
+    /// 50 dB-Hz
+    #[default]
+    Average,
+    /// 40 dB-Hz
+    Poor,
+    /// Manual value provided in dB-Hz, converted to Hertz automatically
+    ManualDbHz(f64),
+}
+
+impl SN0 {
+    /// Note that this returns the data in Hertz not dB-Hz
+    pub(crate) fn value_hz(self) -> f64 {
+        match self {
+            Self::Strong => 10.0_f64.powf(6.5),
+            Self::Average => 10.0_f64.powi(5),
+            Self::Poor => 10.0_f64.powi(4),
+            Self::ManualDbHz(value) => 10.0_f64.powf(value / 10.0),
+        }
+    }
+}
+
+/// Carrier power to noise density for stochastic modeling, typical values.
+/// IMPORTANT: The C/N0 will always be greater or equal to the Signal Power to noise density (C/N0) because the S/N0 for a ranging
+/// tone is the power dedicated to the ranging within the uplink (cf. "modulation index" in the DESCANSO monograph).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum CN0 {
+    /// 70 dB-Hz
+    Strong,
+    /// 55 dB-Hz
+    #[default]
+    Average,
+    /// 45 dB-Hz
+    Poor,
+    /// Manual value provided in dB-Hz, converted to Hertz automatically
+    ManualDbHz(f64),
+}
+
+impl CN0 {
+    /// Note that this returns the data in Hertz not dB-Hz
+    pub(crate) fn value_hz(self) -> f64 {
+        match self {
+            Self::Strong => 10.0_f64.powi(7),
+            Self::Average => 10.0_f64.powf(5.5),
+            Self::Poor => 10.0_f64.powf(4.5),
+            Self::ManualDbHz(value) => 10.0_f64.powf(value / 10.0),
+        }
+    }
+}
+
+/// Carrier frequency helper enum, typical values.
+pub enum CarrierFreq {
+    /// 2.2 GHz
+    SBand,
+    /// 8.4 GHz
+    XBand,
+    /// 32 Ghz
+    KaBand,
+    ManualHz(f64),
+}
+
+impl CarrierFreq {
+    pub(crate) fn value_hz(self) -> f64 {
+        match self {
+            Self::SBand => 2.2e9,
+            Self::XBand => 8.4e9,
+            Self::KaBand => 32e9,
+            Self::ManualHz(value) => value,
+        }
+    }
+}
+
+/// An enum helper with typical chip rates.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum ChipRate {
+    /// 1 kchip/s -- basically emergency ranging
+    Lowest,
+    /// 100 kchip/s -- could be used for weaker links
+    Low,
+    /// 1 Mchip/s -- typical of xGEO/cislunar missions
+    #[default]
+    StandardT4B,
+    /// 10 Mchip/s -- high-precision scientific missions (e.g. gravity modeling)
+    High,
+    /// 25 Mchip/s -- highly specialized missions
+    VeryHigh,
+    /// Provide your own chip rate depending on the ground station configuration
+    ManualHz(f64),
+}
+
+impl ChipRate {
+    pub(crate) fn value_chip_s(self) -> f64 {
+        match self {
+            Self::Lowest => 1e3,
+            Self::Low => 1e5,
+            Self::StandardT4B => 1e6,
+            Self::High => 1e7,
+            Self::VeryHigh => 2.5e7,
+            Self::ManualHz(value) => value,
+        }
+    }
+}
+
+impl StochasticNoise {
+    /// Constructs a high precision zero-mean range noise model (accounting for clock error and thermal error) from
+    /// the Allan deviation of the clock, integration time, chip rate (depends on the ranging code), and
+    /// signal-power-to-noise-density ratio (S/N₀).
+    ///
+    /// NOTE: The Allan Deviation should be provided given the integration time. For example, if the integration time
+    /// is one second, the Allan Deviation should be the deviation over one second.
+    ///
+    /// IMPORTANT: These do NOT include atmospheric noises, which add up to ~10 cm one-sigma.
+    pub fn high_prec_range_km(
+        allan_deviation: f64,
+        integration_time: Duration,
+        chip_rate: ChipRate,
+        s_n0: SN0,
+    ) -> Self {
+        // Compute the thermal noise.
+        let sigma_thermal_km =
+            SPEED_OF_LIGHT_KM_S / (TAU * chip_rate.value_chip_s() * (2.0 * s_n0.value_hz()).sqrt());
+        // Compute the clock noise.
+        let sigma_clock_km =
+            (SPEED_OF_LIGHT_KM_S * allan_deviation * integration_time.to_seconds())
+                / (3.0_f64.sqrt());
+
+        Self {
+            white_noise: Some(WhiteNoise::constant_white_noise(
+                (sigma_clock_km.powi(2) + sigma_thermal_km.powi(2)).sqrt(),
+            )),
+            bias: None,
+        }
+    }
+
+    pub fn high_prec_doppler_km_s(
+        allan_deviation: f64,
+        integration_time: Duration,
+        carrier: CarrierFreq,
+        c_n0: CN0,
+    ) -> Self {
+        // Compute the thermal noise
+        let sigma_thermal_km_s = SPEED_OF_LIGHT_KM_S
+            / (TAU
+                * carrier.value_hz()
+                * (2.0 * c_n0.value_hz() * integration_time.to_seconds()).sqrt());
+
+        // Compute the clock noise.
+        let sigma_clock_km_s = SPEED_OF_LIGHT_KM_S * allan_deviation;
+
+        Self {
+            white_noise: Some(WhiteNoise::constant_white_noise(
+                (sigma_clock_km_s.powi(2) + sigma_thermal_km_s.powi(2)).sqrt(),
+            )),
+            bias: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod link_noise {
+    use super::{CarrierFreq, ChipRate, StochasticNoise, CN0, SN0};
+    use hifitime::Unit;
+    #[test]
+    fn nasa_dsac() {
+        // The DSAC has an Allan Dev of 1e-14 over one day.
+        // Gemini claims that such a good clock likely has the same deviation over 60 seconds (hitting the flicker floor).
+        // But worst case scenario, its AD is the square root of the ratio of one day over 1 minute, or 38 times worse.
+
+        for (case_num, allan_dev) in [1e-14, 3.8e-13].iter().copied().enumerate() {
+            println!("AD = {allan_dev:e}");
+
+            let range_dsac_no_flicker = StochasticNoise::high_prec_range_km(
+                allan_dev,
+                Unit::Minute * 1,
+                ChipRate::StandardT4B,
+                SN0::Average,
+            );
+
+            let range_sigma_m = range_dsac_no_flicker.white_noise.unwrap().sigma * 1e3;
+
+            println!("range sigma = {range_sigma_m:.3e} m",);
+
+            assert!(range_sigma_m.abs() < 1.1e-1);
+
+            let doppler_dsac_no_flicker = StochasticNoise::high_prec_doppler_km_s(
+                allan_dev,
+                Unit::Minute * 1,
+                CarrierFreq::XBand,
+                CN0::Average,
+            );
+
+            let doppler_sigma_m_s = doppler_dsac_no_flicker.white_noise.unwrap().sigma * 1e3;
+
+            println!("doppler sigma = {doppler_sigma_m_s:.3e} m/s");
+
+            match case_num {
+                0 => assert!(doppler_sigma_m_s < 3.2e-6),
+                1 => assert!(doppler_sigma_m_s < 1.2e-4),
+                _ => unreachable!(),
+            };
+        }
+    }
+}

--- a/src/od/noise/mod.rs
+++ b/src/od/noise/mod.rs
@@ -79,7 +79,9 @@ impl StochasticNoise {
                 sigma: 2.0e-3, // 2 m
                 ..Default::default()
             }),
-            bias: Some(GaussMarkov::default_range_km()),
+            // Until Nyx can support bias estimation the default bias is None, cf. https://github.com/nyx-space/nyx/issues/326
+            // bias: Some(GaussMarkov::default_range_km()),
+            bias: None,
         }
     }
 
@@ -90,7 +92,9 @@ impl StochasticNoise {
                 sigma: 3e-6, // 3 mm/s
                 ..Default::default()
             }),
-            bias: Some(GaussMarkov::default_doppler_km_s()),
+            // Until Nyx can support bias estimation the default bias is None, cf. https://github.com/nyx-space/nyx/issues/326
+            // bias: Some(GaussMarkov::default_doppler_km_s()),
+            bias: None,
         }
     }
 
@@ -102,7 +106,9 @@ impl StochasticNoise {
                 sigma: 1.0e-2, // 0.01 deg
                 ..Default::default()
             }),
-            bias: Some(GaussMarkov::default_range_km()),
+            // Until Nyx can support bias estimation the default bias is None, cf. https://github.com/nyx-space/nyx/issues/326
+            // bias: Some(GaussMarkov::default_range_km()),
+            bias: None,
         }
     }
 

--- a/src/od/noise/mod.rs
+++ b/src/od/noise/mod.rs
@@ -32,6 +32,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub mod gauss_markov;
+#[cfg(feature = "premium")]
+pub mod link_specific;
 pub mod white;
 
 pub use gauss_markov::GaussMarkov;

--- a/tests/orbit_determination/measurements.rs
+++ b/tests/orbit_determination/measurements.rs
@@ -395,6 +395,7 @@ fn val_measurement_noise(almanac: Arc<Almanac>) {
     use arrow::datatypes::{DataType, Field, Schema};
     use parquet::arrow::ArrowWriter;
     use serde_arrow::schema::{SchemaLike, TracingOptions};
+    use std::path::PathBuf;
 
     // Build an example trajectory.
     let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
@@ -560,7 +561,9 @@ fn val_measurement_noise(almanac: Arc<Almanac>) {
     // Build the record batch
     let batch = serde_arrow::to_record_batch(&fields, &records).unwrap();
 
-    let file = File::create("data/04_output/noise_val.parquet").unwrap();
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/04_output/noise_val.parquet");
+
+    let file = File::create(&path).unwrap();
 
     let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
 

--- a/tests/orbit_determination/measurements.rs
+++ b/tests/orbit_determination/measurements.rs
@@ -563,11 +563,7 @@ fn val_measurement_noise(almanac: Arc<Almanac>) {
     let file = File::create("data/04_output/noise_val.parquet").unwrap();
 
     let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
-    // let batch = RecordBatch::try_new(schema, record)
-    //     .context(ArrowSnafu {
-    //         action: "writing OD results (building batch record)",
-    //     })
-    //     .context(ODIOSnafu)?;
 
-    writer.write(&batch).unwrap()
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
 }


### PR DESCRIPTION
# Summary

- Add the `premium` crate feature, along with documentation in the README about who it affects
- Add link specific noise modeling for OD: specify the carrier frequency, S/N0, etc. and it'll build a high precision Range and Doppler noise model (without accounting to tropospheric and ionospheric errors)
- Validate existing noise modeling

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

- Add link specific noise modeling for OD: specify the carrier frequency, S/N0, etc. and it'll build a high precision Range and Doppler noise model (without accounting to tropospheric and ionospheric errors)
- Add filtering of tracking data by measurement type

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

- Validate noise modeling, and export it to parquet

<img width="1831" height="935" alt="image" src="https://github.com/user-attachments/assets/ff3198bf-7645-4c18-83a9-e6fa10e856df" />
<img width="1831" height="935" alt="image" src="https://github.com/user-attachments/assets/1a7d586e-7943-413b-85c7-fa180c39f33a" />

Not the most useful plot but it's still obviously white noise.

<img width="1831" height="830" alt="image" src="https://github.com/user-attachments/assets/e84ef0a4-6b18-46ff-a60b-693c09cc15d6" />

Here is the real test: check that we're in the 99.7% all the time

```
total mass = 0.000 kg @  [Earth J2000] 2025-08-22T00:00:00 TAI	position = [143.525251, 56.873623, -92.552112] km	velocity = [-28.969769, 59.236404, -8.523894] km/s  Coast
Trajectory in Earth J2000 (μ = 398600.435436096 km^3/s^2, eq. radius = 6378.14 km, polar radius = 6356.75 km, f = 0.0033536422844278) from 2025-08-22T00:00:00 TAI to 2025-08-24T13:03:22.254204690 TAI (2 days 13 h 3 min 22 s 254 ms 204 μs 690 ns, or 219802.254 s) [535 states]
percentage IN FAMILY for Range = 99.7239 %
percentage IN FAMILY for Doppler = 99.8896 %
percentage IN FAMILY for Azimuth = 99.6687 %
percentage IN FAMILY for Elevation = 99.7791 %
```

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->