### PR TITLE
Tuned the interlink filter when dispersions enabled

### DIFF
--- a/tests/orbit_determination/predict_validation.rs
+++ b/tests/orbit_determination/predict_validation.rs
@@ -15,7 +15,7 @@ use nyx::propagators::Propagator;
 use nyx::time::{Epoch, TimeUnits};
 use nyx::Spacecraft;
 
-use anise::{constants::frames::EARTH_J2000, prelude::Almanac};
+use anise::prelude::Almanac;
 use rstest::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -31,7 +31,6 @@ fn almanac() -> Arc<Almanac> {
 fn val_pure_predictor(almanac: Arc<Almanac>) {
     let _ = pretty_env_logger::try_init();
 
-    let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
     let iau_earth = almanac.frame_from_uid(IAU_EARTH_FRAME).unwrap();
     let moon_iau = almanac.frame_from_uid(IAU_MOON_FRAME).unwrap();
 

--- a/tests/utils/plot_od_orbital_elements.py
+++ b/tests/utils/plot_od_orbital_elements.py
@@ -1,25 +1,22 @@
-import argparse
 import polars as pl
 import plotly.graph_objs as go
 from plotly.subplots import make_subplots
 import click
 
+
 @click.command
 @click.option("-p", "--path", type=str)
 @click.option("-m", "--multiplier", type=float, default=1.0)
-def plot_orbit_elements(
-    path: str,
-    multiplier: int
-):
+def plot_orbit_elements(path: str, multiplier: int):
     """
     Plots the orbital elements: SMA, ECC, INC, RAAN, AOP, TA, True Longitude, AOL
     """
 
     df = pl.read_parquet(path)
 
-    df = df.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")).sort(
-        "Epoch (UTC)", descending=False
-    )
+    df = df.with_columns(
+        pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")
+    ).sort("Epoch (UTC)", descending=False)
 
     columns = [
         "Sigma sma (km)",

--- a/tests/utils/plot_od_orbital_elements.py
+++ b/tests/utils/plot_od_orbital_elements.py
@@ -1,0 +1,63 @@
+import argparse
+import polars as pl
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+import click
+
+@click.command
+@click.option("-p", "--path", type=str)
+@click.option("-m", "--multiplier", type=float, default=1.0)
+def plot_orbit_elements(
+    path: str,
+    multiplier: int
+):
+    """
+    Plots the orbital elements: SMA, ECC, INC, RAAN, AOP, TA, True Longitude, AOL
+    """
+
+    df = pl.read_parquet(path)
+
+    df = df.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")).sort(
+        "Epoch (UTC)", descending=False
+    )
+
+    columns = [
+        "Sigma sma (km)",
+        "Sigma ecc",
+        "Sigma inc (deg)",
+        "Sigma raan (deg)",
+        "Sigma aop (deg)",
+        "Sigma ta (deg)",
+        "Sigma aol (deg)",
+        "Sigma tlong (deg)",
+    ]
+
+    fig = make_subplots(
+        rows=4,
+        cols=2,
+        subplot_titles=[f"{multiplier}-{col}" for col in columns],
+        shared_xaxes=True,
+        vertical_spacing=0.1,
+    )
+
+    row_i = 0
+    col_i = 0
+
+    for col in columns:
+        name = f"{multiplier}-{col}"
+
+        fig.add_trace(
+            go.Scattergl(x=df["Epoch (UTC)"], y=df[col] * multiplier, name=name),
+            row=row_i + 1,
+            col=col_i + 1,
+        )
+
+        col_i = (col_i + 1) % 2
+        if col_i == 0:
+            row_i = (row_i + 1) % 4
+
+    fig.show()
+
+
+if __name__ == "__main__":
+    plot_orbit_elements()

--- a/tests/utils/plot_od_rslt.py
+++ b/tests/utils/plot_od_rslt.py
@@ -13,19 +13,21 @@ import click
 def main(path: str, wstats: bool, error_ric: str):
     df = pl.read_parquet(path)
 
-    df = (
-        df.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f"))
-        .sort("Epoch (UTC)", descending=False)
-    )
+    df = df.with_columns(
+        pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")
+    ).sort("Epoch (UTC)", descending=False)
 
     if error_ric:
         ricdf = pl.read_parquet(error_ric)
-        ricdf = (
-            ricdf.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f"))
-            .sort("Epoch (UTC)", descending=False)
-        )
+        ricdf = ricdf.with_columns(
+            pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")
+        ).sort("Epoch (UTC)", descending=False)
 
-        px.line(ricdf, x="Epoch (UTC)", y=["Delta X (RIC) (km)", "Delta Y (RIC) (km)", "Delta Z (RIC) (km)"])
+        px.line(
+            ricdf,
+            x="Epoch (UTC)",
+            y=["Delta X (RIC) (km)", "Delta Y (RIC) (km)", "Delta Z (RIC) (km)"],
+        )
 
     all_msr_types = ["Range (km)", "Doppler (km/s)", "Azimuth (deg)", "Elevation (deg)"]
     msr_type_count = 0
@@ -79,15 +81,21 @@ def main(path: str, wstats: bool, error_ric: str):
     # Plot the residual ratios
     ratio_color = "Residual Rejected" if len(df.unique("Tracker")) == 1 else "Tracker"
     px.scatter(df, x="Epoch (UTC)", y="Residual ratio", color=ratio_color).show()
-    
+
     # Plot the RIC uncertainty
     px.line(
-        df, x="Epoch (UTC)", y=["Sigma X (RIC) (km)", "Sigma Y (RIC) (km)", "Sigma Z (RIC) (km)"]
+        df,
+        x="Epoch (UTC)",
+        y=["Sigma X (RIC) (km)", "Sigma Y (RIC) (km)", "Sigma Z (RIC) (km)"],
     ).show()
 
     if wstats:
         for msr in msr_types:
-            px.scatter(df, x="Epoch (UTC)", y=[f"Real observation: {msr}", f"Computed observation: {msr}"]).show()
+            px.scatter(
+                df,
+                x="Epoch (UTC)",
+                y=[f"Real observation: {msr}", f"Computed observation: {msr}"],
+            ).show()
 
         # Convert the Polars column to a NumPy array for compatibility with scipy and Plotly
         residual_ratio = df["Residual ratio"].drop_nulls().to_numpy()
@@ -107,13 +115,23 @@ def main(path: str, wstats: bool, error_ric: str):
         # Add scatter points
         fig_qq.add_trace(
             go.Scatter(
-                x=qq[0][0], y=qq[0][1], mode="markers", name="Residuals ratios (QQ)", marker=dict(color="blue")
+                x=qq[0][0],
+                y=qq[0][1],
+                mode="markers",
+                name="Residuals ratios (QQ)",
+                marker=dict(color="blue"),
             )
         )
 
         # Add the theoretical line
         fig_qq.add_trace(
-            go.Scatter(x=x_qq, y=y_qq, mode="lines", name="Theoretical Normal", line=dict(color="red"))
+            go.Scatter(
+                x=x_qq,
+                y=y_qq,
+                mode="lines",
+                name="Theoretical Normal",
+                line=dict(color="red"),
+            )
         )
 
         # Update layout

--- a/tests/utils/plot_orbital_elements.py
+++ b/tests/utils/plot_orbital_elements.py
@@ -1,0 +1,62 @@
+import argparse
+import polars as pl
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+
+
+def plot_orbit_elements(
+    df: pl.DataFrame,
+):
+    """
+    Plots the orbital elements: SMA, ECC, INC, RAAN, AOP, TA, True Longitude, AOL
+    """
+
+    df = df.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")).sort(
+        "Epoch (UTC)", descending=False
+    )
+
+    columns = [
+        "sma (km)",
+        "ecc",
+        "inc (deg)",
+        "raan (deg)",
+        "aop (deg)",
+        "ta (deg)",
+        "aol (deg)",
+        "tlong (deg)",
+    ]
+
+    fig = make_subplots(
+        rows=4,
+        cols=2,
+        subplot_titles=columns,
+        shared_xaxes=True,
+        vertical_spacing=0.1,
+    )
+
+    row_i = 0
+    col_i = 0
+
+    for col in columns:
+        name = col
+
+        fig.add_trace(
+            go.Scattergl(x=df["Epoch (UTC)"], y=df[col], name=name),
+            row=row_i + 1,
+            col=col_i + 1,
+        )
+        col_i = (col_i + 1) % 2
+        if col_i == 0:
+            row_i = (row_i + 1) % 4
+
+    fig.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Plot orbital element")
+    parser.add_argument("pq", type=str, help="Path to the parquet file")
+    args = parser.parse_args()
+    
+    df = pl.read_parquet(args.pq)
+
+    plot_orbit_elements(df)

--- a/tests/utils/plot_orbital_elements.py
+++ b/tests/utils/plot_orbital_elements.py
@@ -1,19 +1,22 @@
-import argparse
 import polars as pl
 import plotly.graph_objs as go
 from plotly.subplots import make_subplots
+import click
 
-
+@click.command
+@click.option("-p", "--path", type=str)
 def plot_orbit_elements(
-    df: pl.DataFrame,
+    path:str
 ):
     """
     Plots the orbital elements: SMA, ECC, INC, RAAN, AOP, TA, True Longitude, AOL
     """
 
-    df = df.with_columns(pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")).sort(
-        "Epoch (UTC)", descending=False
-    )
+    df = pl.read_parquet(path)
+
+    df = df.with_columns(
+        pl.col("Epoch (UTC)").str.to_datetime("%Y-%m-%dT%H:%M:%S%.f")
+    ).sort("Epoch (UTC)", descending=False)
 
     columns = [
         "sma (km)",
@@ -53,10 +56,4 @@ def plot_orbit_elements(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Plot orbital element")
-    parser.add_argument("pq", type=str, help="Path to the parquet file")
-    args = parser.parse_args()
-    
-    df = pl.read_parquet(args.pq)
-
-    plot_orbit_elements(df)
+    plot_orbit_elements()


### PR DESCRIPTION
# Summary

- Tuned the interlink filter when dispersions are enable
- Added a orbital element covariance plotting tool

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

Test utils now includes covariance plots with whichever sigma count the user wants. Add RIC error plots to the OD plotter.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Here come the plots!

### Residuals

_Note that the first measurement immediately corrects the filter_

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/0747624d-f3ce-4f15-a904-02aecca4bf24" />

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/5f953bee-186b-4ed0-a50d-24960d6f01bc" />

In practice, one would probably restart the filter after it converges here to reduce the noise level and have the residual ratios fill up the whole 3 sigma bounds.

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/f2de91d7-d74a-4d7e-a49a-0cce9ba893a1" />

### RIC Uncertainty

This shows that we don't have good crosstrack visibility on this CAPS-like interlink.

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/d41316e9-e764-402c-9b0f-d16356f78df8" />

### Orbital element uncertainties
<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/8710730a-f440-4004-aca2-30d2b4d18097" />

### Kalman filter gains

This shows that for about 45 minutes, the filter hasn't converged yet so it is making pretty large adjustments, but quickly converges on a solution.

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/2179d8bc-1135-41b6-9630-6d34ad4119da" />


## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->