### PR TITLE
Chore: Update obsolete comments in OD tests

### DIFF
--- a/tests/orbit_determination/blse.rs
+++ b/tests/orbit_determination/blse.rs
@@ -81,7 +81,6 @@ fn blse_robust_large_disp_cov_test(
         ),
     ]);
 
-    // Note that we do not have Goldstone so we can test enabling and disabling the EKF.
     let mut devices = BTreeMap::new();
     // devices.insert("Madrid".to_string(), dss65_madrid);
     devices.insert("Canberra".to_string(), dss34_canberra);

--- a/tests/orbit_determination/multi_body.rs
+++ b/tests/orbit_determination/multi_body.rs
@@ -129,9 +129,9 @@ fn od_val_multi_body_ckf_perfect_stations(
     let arc = arc_sim.generate_measurements(almanac.clone()).unwrap();
     arc.to_parquet_simple("multi_body.parquet").unwrap();
 
-    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
-    // We expect the estimated orbit to be perfect since we're using strictly the same dynamics, no noise on
-    // the measurements, and the same time step.
+    // Now that we have the truth data, let's start an OD and compute the estimates. We expect the
+    // estimated orbit to be perfect since we're using strictly the same dynamics, no noise on the
+    // measurements, and the same time step.
     let covar_radius_km = 1.0e-3_f64.powi(2);
     let covar_velocity_km_s = 1.0e-6_f64.powi(2);
     let init_covar = SMatrix::<f64, 9, 9>::from_diagonal(&SVector::<f64, 9>::from_iterator([
@@ -245,7 +245,7 @@ fn multi_body_ckf_covar_map_cov_test(
     let dt = Epoch::from_gregorian_tai_at_midnight(2020, 1, 1);
     let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
 
-    // Generate the truth data on one thread.
+    // Generate the truth data.
     let bodies = vec![MOON, SUN, JUPITER_BARYCENTER];
     let orbital_dyn = OrbitalDynamics::point_masses(bodies);
     let setup = Propagator::new(
@@ -254,7 +254,6 @@ fn multi_body_ckf_covar_map_cov_test(
         opts,
     );
     let mut prop = setup.with(initial_state.into(), almanac.clone());
-
     let (_, traj) = prop.for_duration_with_traj(prop_time).unwrap();
 
     // Simulate tracking data
@@ -263,9 +262,9 @@ fn multi_body_ckf_covar_map_cov_test(
 
     let arc = arc_sim.generate_measurements(almanac.clone()).unwrap();
 
-    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
-    // We expect the estimated orbit to be perfect since we're using strictly the same dynamics, no noise on
-    // the measurements, and the same time step.
+    // Now that we have the truth data, let's start an OD. We expect the estimated orbit to be
+    // perfect on measurement updates since we're using strictly the same dynamics and have no
+    // noise on the measurements.
     let covar_radius_km = 1.0e-3_f64.powi(2);
     let covar_velocity_km_s = 1.0e-6_f64.powi(2);
     let init_covar = SMatrix::<f64, 9, 9>::from_diagonal(&SVector::<f64, 9>::from_iterator([

--- a/tests/orbit_determination/robust.rs
+++ b/tests/orbit_determination/robust.rs
@@ -85,7 +85,6 @@ fn od_robust_large_disp_test_two_way(almanac: Arc<Almanac>) {
         (dss34_canberra.name.clone(), TrkConfig::default()),
     ]);
 
-    // Note that we do not have Goldstone so we can test enabling and disabling the EKF.
     let mut devices = BTreeMap::new();
     devices.insert("Madrid".to_string(), dss65_madrid);
     devices.insert("Canberra".to_string(), dss34_canberra);
@@ -153,8 +152,9 @@ fn od_robust_large_disp_test_two_way(almanac: Arc<Almanac>) {
     assert_eq!(arc.unique_types().len(), 1);
     assert_eq!(arc.unique_types()[0], MeasurementType::Range);
 
-    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
-    // We expect the estimated orbit to be _nearly_ perfect because we've removed SATURN_BARYCENTER from the estimated trajectory
+    // Now that we have the truth data, let's start an OD and compute the estimates. We expect the
+    // estimated orbit to be _nearly_ perfect because we've removed SATURN_BARYCENTER from the
+    // estimated trajectory
     let bodies = vec![MOON, SUN, JUPITER_BARYCENTER];
     let estimator = SpacecraftDynamics::new(OrbitalDynamics::point_masses(bodies));
     let setup = Propagator::default(estimator);

--- a/tests/orbit_determination/simulator.rs
+++ b/tests/orbit_determination/simulator.rs
@@ -237,7 +237,6 @@ fn od_with_modulus_cov_test(
     arc.apply_moduli();
 
     // Increase the noise on the OD process
-    // Set a bias instead of assuming a modulus.
     for device in devices.values_mut() {
         for (_, stochastics) in device.stochastic_noises.as_mut().unwrap().iter_mut() {
             *stochastics *= 2.0;

--- a/tests/orbit_determination/trackingarc.rs
+++ b/tests/orbit_determination/trackingarc.rs
@@ -193,7 +193,7 @@ fn trkconfig_zero_inclusion(
 /// Test invalid tracking configurations
 #[rstest]
 fn trkconfig_invalid(traj: Traj<Spacecraft>, devices: BTreeMap<String, GroundStation>) {
-    // Build a tracking config where the exclusion range is less than the sampling rate
+    // Build a tracking config with a zero-duration strand, which is invalid.
     let trkcfg = TrkConfig::builder()
         .strands(vec![Strand {
             start: traj.first().epoch(),
@@ -255,7 +255,7 @@ fn trkconfig_cadence(
     devices: BTreeMap<String, GroundStation>,
     almanac: Arc<Almanac>,
 ) {
-    // Build the configs map with a single ground station
+    // Build the configs map for two ground stations with different cadences.
     let mut configs = BTreeMap::new();
 
     configs.insert(
@@ -286,7 +286,7 @@ fn trkconfig_cadence(
 
     let arc = trk.generate_measurements(almanac).unwrap();
 
-    // Check the sampling of the arc is one minute: we don't have any overlap of availability and the default sampling is one minute.
+    // The minimum separation should be driven by the Canberra station's sampling rate.
     assert_eq!(
         arc.min_duration_sep().unwrap(),
         26.1.seconds(),

--- a/tests/orbit_determination/two_body.rs
+++ b/tests/orbit_determination/two_body.rs
@@ -238,8 +238,6 @@ fn od_tb_val_with_arc(
     // Define the propagator information.
     let duration = 1 * Unit::Day;
 
-    // Define the storages (channels for the states and a map for the measurements).
-
     // Define state information.
     let eme2k = almanac.frame_from_uid(EARTH_J2000).unwrap();
     let dt = Epoch::from_gregorian_tai_at_midnight(2020, 1, 1);
@@ -428,7 +426,7 @@ fn od_tb_val_ckf_fixed_step_perfect_stations(
     let dt = Epoch::from_gregorian_tai_at_midnight(2020, 1, 1);
     let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
 
-    // Generate the truth data on one thread.
+    // Generate the truth data.
     let orbital_dyn = SpacecraftDynamics::new(OrbitalDynamics::two_body());
 
     let setup = Propagator::new(orbital_dyn, IntegratorMethod::RungeKutta4, opts);
@@ -689,7 +687,7 @@ fn od_tb_val_az_el_ckf_fixed_step_perfect_stations(
     let dt = Epoch::from_gregorian_tai_at_midnight(2020, 1, 1);
     let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
 
-    // Generate the truth data on one thread.
+    // Generate the truth data.
     let orbital_dyn = SpacecraftDynamics::new(OrbitalDynamics::two_body());
 
     let setup = Propagator::new(orbital_dyn, IntegratorMethod::RungeKutta4, opts);
@@ -1080,7 +1078,7 @@ fn od_tb_fixed_step_perfect_stations_snc_covar_map(
     // Define the initial estimate
     let initial_estimate = KfEstimate::from_covar(initial_state.into(), init_covar);
 
-    // Define the process noise to assume an unmodeled acceleration of 1e-3 km^2/s^2 on X, Y and Z in the ECI frame
+    // Define the process noise to assume an unmodeled acceleration on X, Y and Z in the ECI frame.
     let sigma_q = 1e-8_f64.powi(2);
     let process_noise =
         ProcessNoise3D::from_diagonal(2 * Unit::Minute, &[sigma_q, sigma_q, sigma_q]);
@@ -1154,10 +1152,7 @@ fn od_tb_ckf_map_covar(almanac: Arc<Almanac>) {
     let dt = Epoch::from_gregorian_tai_at_midnight(2020, 1, 1);
     let initial_state = Orbit::keplerian(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt, eme2k);
 
-    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
-    // We expect the estimated orbit to be perfect since we're using strictly the same dynamics, no noise on
-    // the measurements, and the same time step.
-
+    // Test that the covariance inflates correctly during a prediction-only propagation.
     let setup = Propagator::new(
         SpacecraftDynamics::new(OrbitalDynamics::two_body()),
         IntegratorMethod::RungeKutta4,
@@ -1390,7 +1385,7 @@ fn od_tb_fixed_step_perfect_stations_several_snc_covar_map(
     // Define the initial estimate
     let initial_estimate = KfEstimate::from_covar(initial_state.into(), init_covar);
 
-    // Define the process noise to assume an unmodeled acceleration of 1e-3 km^2/s^2 on X, Y and Z in the ECI frame
+    // Define the process noise to assume an unmodeled acceleration on X, Y and Z in the ECI frame.
     let sigma_q1 = 1e-7_f64.powi(2);
     let process_noise1 =
         ProcessNoise3D::from_diagonal(2 * Unit::Day, &[sigma_q1, sigma_q1, sigma_q1]);


### PR DESCRIPTION
This commit updates and removes obsolete, incorrect, or unclear comments across all of the test files in the `tests/orbit_determination` directory.

This includes:
- Removing several instances of the obsolete "on one thread" comment.
- Correcting misleading comments about test configurations (e.g., noise models, invalid setups).
- Removing confusing comments that were out of sync with the code.

