### PR TITLE
Fix two bugs in Targeter finite-difference corrector

### DIFF
--- a/src/md/opti/raphson_finite_diff.rs
+++ b/src/md/opti/raphson_finite_diff.rs
@@ -186,8 +186,7 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
                     .context(AstroSnafu)?
                     .rot_mat;
 
-                let velocity_correction =
-                    dcm_vnc2inertial * state_correction.fixed_rows::<3>(3);
+                let velocity_correction = dcm_vnc2inertial * state_correction.fixed_rows::<3>(3);
                 xi.orbit.apply_dv_km_s(velocity_correction);
             } else {
                 xi.orbit.radius_km += state_correction.fixed_rows::<3>(0).to_owned();

--- a/src/md/opti/raphson_finite_diff.rs
+++ b/src/md/opti/raphson_finite_diff.rs
@@ -94,7 +94,8 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
 
         let mut finite_burn_target = false;
 
-        // Apply the initial guess
+        // Apply the initial guess: first accumulate, then apply once (matching
+        // the pattern used in the iteration loop at lines ~608-729).
         for (i, var) in self.variables.iter().enumerate() {
             // Check the validity (this function will report to log and raise an error)
             var.valid()?;
@@ -171,25 +172,27 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
                 info!("Initial maneuver guess: {mnvr}");
             } else {
                 state_correction[var.component.vec_index()] += var.init_guess;
-                // Now, let's apply the correction to the initial state
-                if let Some(frame) = self.correction_frame {
-                    // The following will error if the frame is not local
-                    let dcm_vnc2inertial = frame
-                        .dcm_to_inertial(xi.orbit)
-                        .context(AstroPhysicsSnafu)
-                        .context(AstroSnafu)?
-                        .rot_mat;
-
-                    let velocity_correction =
-                        dcm_vnc2inertial * state_correction.fixed_rows::<3>(3);
-                    xi.orbit.apply_dv_km_s(velocity_correction);
-                } else {
-                    xi.orbit.radius_km += state_correction.fixed_rows::<3>(0).to_owned();
-                    xi.orbit.velocity_km_s += state_correction.fixed_rows::<3>(3).to_owned();
-                }
             }
 
             total_correction[i] += var.init_guess;
+        }
+
+        // Apply the accumulated initial guess to xi (once, after the loop)
+        if !finite_burn_target {
+            if let Some(frame) = self.correction_frame {
+                let dcm_vnc2inertial = frame
+                    .dcm_to_inertial(xi.orbit)
+                    .context(AstroPhysicsSnafu)
+                    .context(AstroSnafu)?
+                    .rot_mat;
+
+                let velocity_correction =
+                    dcm_vnc2inertial * state_correction.fixed_rows::<3>(3);
+                xi.orbit.apply_dv_km_s(velocity_correction);
+            } else {
+                xi.orbit.radius_km += state_correction.fixed_rows::<3>(0).to_owned();
+                xi.orbit.velocity_km_s += state_correction.fixed_rows::<3>(3).to_owned();
+            }
         }
 
         let mut prev_err_norm = f64::INFINITY;
@@ -545,8 +548,7 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
                         .dcm_to_inertial(corrected_state.orbit)
                         .context(AstroPhysicsSnafu)
                         .context(AstroSnafu)?
-                        .rot_mat
-                        .transpose();
+                        .rot_mat;
 
                     let velocity_correction =
                         dcm_vnc2inertial * state_correction.fixed_rows::<3>(3);

--- a/src/md/opti/raphson_finite_diff.rs
+++ b/src/md/opti/raphson_finite_diff.rs
@@ -95,7 +95,7 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
         let mut finite_burn_target = false;
 
         // Apply the initial guess: first accumulate, then apply once (matching
-        // the pattern used in the iteration loop at lines ~608-729).
+        // the pattern used in the iteration loop).
         for (i, var) in self.variables.iter().enumerate() {
             // Check the validity (this function will report to log and raise an error)
             var.valid()?;


### PR DESCRIPTION
## Summary

- Remove spurious `.transpose()` on VNC→inertial DCM in the convergence path of `raphson_finite_diff.rs`, which caused `apply_with_traj()` to fail verification on any VNC-frame targeting
- Move init_guess application outside the per-variable loop to prevent cumulative over-application (first variable's guess applied 3×, second 2×, third 1×), which caused verification failures on sensitive arcs even in inertial frame

## Details

**Bug 1 — DCM transpose:** The convergence branch (building `corrected_state` from `xi_start + total_correction`) transposed the `dcm_to_inertial` rotation matrix at line ~549, effectively rotating inertial→VNC instead of VNC→inertial. All three other call sites in the same file (init guess application, Jacobian perturbation, iteration step) use the DCM **without** transpose.

**Bug 2 — Init guess double-counting:** `state_correction` was applied to `xi` inside the `for (i, var)` loop. With 3 velocity variables `[vx, vy, vz]`:
- After variable 0: `xi.vel += [vx, 0, 0]`
- After variable 1: `xi.vel += [vx, vy, 0]` (accumulated) → total `[2·vx, vy, 0]`
- After variable 2: `xi.vel += [vx, vy, vz]` → total `[3·vx, 2·vy, vz]`

But `total_correction` correctly stores `[vx, vy, vz]`, so the convergence path's `corrected_state` disagrees with the iterated `xi`. The fix moves application outside the loop, matching the pattern already used in the iteration loop (~lines 608-729).

Neither bug manifests when `init_guess = 0` (the default from `Vary::into()`), which is why existing tests pass. Both bugs trigger on sensitive, long-arc targeting with nonzero initial guesses (e.g., trans-lunar injection).

## Test plan

- [x] All 83 existing `cargo test --lib` tests pass
- [x] Verified with a trans-lunar injection scenario (HEO → lunar flyby): Nyx Targeter now converges in 4 iterations with `apply_with_traj` verification passing

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)