### PR TITLE
fix(lambert): direction-of-motion handling in Izzo and Auto dispatch

### DIFF
--- a/src/tools/lambert/godding.rs
+++ b/src/tools/lambert/godding.rs
@@ -211,4 +211,44 @@ mod ut_lambert_gooding {
         assert!((sol.v_init_km_s - exp_vi).norm() < 1e-6);
         assert!((sol.v_final_km_s - exp_vf).norm() < 1e-6);
     }
+
+    #[test]
+    fn test_lambert_gooding_direction_toggle_ih_negative() {
+        // Symmetry lock: on the Gooding path, the direction toggle is a
+        // simple ±1 on the chord term, independent of i_h.z. This test
+        // pins that invariant so ShortWay/LongWay can never collapse
+        // to a single solution on i_h.z<0 geometries.
+        let frame = Frame {
+            ephemeris_id: 301,
+            orientation_id: 0,
+            mu_km3_s2: Some(3.98600433e5),
+            shape: None,
+        };
+        let t0 = Epoch::from_gregorian_utc_at_midnight(2025, 1, 1);
+
+        let r1 = Vector3::new(7000.0, 0.0, 0.0);
+        let r2 = Vector3::new(0.0, -7000.0, -500.0);
+
+        let initial = Orbit {
+            radius_km: r1,
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0,
+            frame,
+        };
+        let final_ = Orbit {
+            radius_km: r2,
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0 + Unit::Minute * 60.0,
+            frame,
+        };
+        let input = LambertInput::from_planetary_states(initial, final_).unwrap();
+
+        let short = gooding(input, TransferKind::ShortWay).unwrap();
+        let long = gooding(input, TransferKind::LongWay).unwrap();
+
+        assert!(
+            (short.v_init_km_s - long.v_init_km_s).norm() > 1e-3,
+            "Gooding short/long-way collapsed on i_h.z<0 geometry",
+        );
+    }
 }

--- a/src/tools/lambert/izzo.rs
+++ b/src/tools/lambert/izzo.rs
@@ -74,7 +74,21 @@ pub fn izzo(input: LambertInput, kind: TransferKind) -> Result<LambertSolution, 
     let lambda = 1.0 - c_norm / s;
     let mut m_lambda = lambda.sqrt();
 
-    let retrograde = matches!(kind, TransferKind::LongWay);
+    let revs = match kind {
+        TransferKind::NRevs(n) => n.into(),
+        _ => 0_u32,
+    };
+
+    // Izzo's `find_xy` handles multi-rev geometry, so the direction toggle
+    // below is only meaningful for single-rev kinds; default NRevs to the
+    // prograde branch to preserve historical behavior. `direction_of_motion`
+    // returns `MultiRevNotSupported` for NRevs, hence the guard.
+    let dm = if matches!(kind, TransferKind::NRevs(_)) {
+        1.0
+    } else {
+        kind.direction_of_motion(&r_final, &r_init)?
+    };
+    let retrograde = dm < 0.0;
 
     let (mut i_t1, mut i_t2) = if retrograde {
         m_lambda = -m_lambda;
@@ -93,10 +107,7 @@ pub fn izzo(input: LambertInput, kind: TransferKind) -> Result<LambertSolution, 
     let (x, y) = find_xy(
         m_lambda,
         t,
-        match kind {
-            TransferKind::NRevs(revs) => revs.into(),
-            _ => 0,
-        },
+        revs,
         MAX_ITERATIONS,
         LAMBERT_EPSILON,
         LAMBERT_EPSILON,
@@ -560,6 +571,84 @@ mod ut_lambert_izzo {
             "direction toggle ignored — short and long-way collapsed: short={:?}, long={:?}",
             short.v_init_km_s,
             long.v_init_km_s,
+        );
+    }
+
+    #[test]
+    fn test_lambert_izzo_auto_matches_longway_for_long_arc() {
+        let frame = Frame {
+            ephemeris_id: 301,
+            orientation_id: 0,
+            mu_km3_s2: Some(3.98600433e5),
+            shape: None,
+        };
+        let t0 = Epoch::from_gregorian_utc_at_midnight(2025, 1, 1);
+
+        // dnu = 3pi/2: Auto should pick long-way.
+        let initial = Orbit {
+            radius_km: Vector3::new(8000.0, 0.0, 0.0),
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0,
+            frame,
+        };
+        let final_ = Orbit {
+            radius_km: Vector3::new(0.0, -8000.0, 0.0),
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0 + Unit::Minute * 60.0,
+            frame,
+        };
+        let input = LambertInput::from_planetary_states(initial, final_).unwrap();
+
+        let auto = izzo(input, TransferKind::Auto).unwrap();
+        let long = izzo(input, TransferKind::LongWay).unwrap();
+        let short = izzo(input, TransferKind::ShortWay).unwrap();
+
+        assert!(
+            (auto.v_init_km_s - long.v_init_km_s).norm() < 1e-10,
+            "Auto should match LongWay for long-arc geometry",
+        );
+        assert!(
+            (auto.v_init_km_s - short.v_init_km_s).norm() > 1e-3,
+            "Auto should differ from ShortWay for long-arc geometry",
+        );
+    }
+
+    #[test]
+    fn test_lambert_izzo_auto_matches_shortway_for_short_arc() {
+        let frame = Frame {
+            ephemeris_id: 301,
+            orientation_id: 0,
+            mu_km3_s2: Some(3.98600433e5),
+            shape: None,
+        };
+        let t0 = Epoch::from_gregorian_utc_at_midnight(2025, 1, 1);
+
+        // dnu = pi/2: Auto should pick short-way.
+        let initial = Orbit {
+            radius_km: Vector3::new(8000.0, 0.0, 0.0),
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0,
+            frame,
+        };
+        let final_ = Orbit {
+            radius_km: Vector3::new(0.0, 8000.0, 0.0),
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0 + Unit::Minute * 60.0,
+            frame,
+        };
+        let input = LambertInput::from_planetary_states(initial, final_).unwrap();
+
+        let auto = izzo(input, TransferKind::Auto).unwrap();
+        let short = izzo(input, TransferKind::ShortWay).unwrap();
+        let long = izzo(input, TransferKind::LongWay).unwrap();
+
+        assert!(
+            (auto.v_init_km_s - short.v_init_km_s).norm() < 1e-10,
+            "Auto should match ShortWay for short-arc geometry",
+        );
+        assert!(
+            (auto.v_init_km_s - long.v_init_km_s).norm() > 1e-3,
+            "Auto should differ from LongWay for short-arc geometry",
         );
     }
 }

--- a/src/tools/lambert/izzo.rs
+++ b/src/tools/lambert/izzo.rs
@@ -63,14 +63,20 @@ pub fn izzo(input: LambertInput, kind: TransferKind) -> Result<LambertSolution, 
     let mut i_h = i_r1.cross(&i_r2);
     i_h /= i_h.norm(); // Ensure normalization
 
+    // Normalize orientation so i_h points along +z, matching the
+    // lamberthub reference. The user's prograde/retrograde choice is
+    // then applied on its own, decoupled from ECI-frame parity.
+    if i_h.z < 0.0 {
+        i_h = -i_h;
+    }
+
     // Geometry of the problem
     let lambda = 1.0 - c_norm / s;
     let mut m_lambda = lambda.sqrt();
 
     let retrograde = matches!(kind, TransferKind::LongWay);
 
-    let (mut i_t1, mut i_t2) = if i_h.z < 0.0 || retrograde {
-        // Transfer angle greater than 180 degrees
+    let (mut i_t1, mut i_t2) = if retrograde {
         m_lambda = -m_lambda;
         (i_r1.cross(&i_h), i_r2.cross(&i_h))
     } else {
@@ -512,6 +518,48 @@ mod ut_lambert_izzo {
         assert!(
             (sol.v_inf_outgoing_right_ascension_deg() + 152.2652291).abs() < 1e-6,
             "wrong outgoing RA"
+        );
+    }
+
+    #[test]
+    fn test_lambert_izzo_direction_toggle_ih_negative() {
+        // Regression: geometry with i_h.z < 0 must still respect the caller's
+        // ShortWay/LongWay choice. The pre-fix branch
+        // `if i_h.z < 0.0 || retrograde` collapsed both into one solution.
+        let frame = Frame {
+            ephemeris_id: 301,
+            orientation_id: 0,
+            mu_km3_s2: Some(3.98600433e5),
+            shape: None,
+        };
+        let t0 = Epoch::from_gregorian_utc_at_midnight(2025, 1, 1);
+
+        // r1 × r2 = (0, 3.5e6, -4.9e7) → i_h.z < 0
+        let r1 = Vector3::new(7000.0, 0.0, 0.0);
+        let r2 = Vector3::new(0.0, -7000.0, -500.0);
+
+        let initial = Orbit {
+            radius_km: r1,
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0,
+            frame,
+        };
+        let final_ = Orbit {
+            radius_km: r2,
+            velocity_km_s: Vector3::zeros(),
+            epoch: t0 + Unit::Minute * 60.0,
+            frame,
+        };
+        let input = LambertInput::from_planetary_states(initial, final_).unwrap();
+
+        let short = izzo(input, TransferKind::ShortWay).unwrap();
+        let long = izzo(input, TransferKind::LongWay).unwrap();
+
+        assert!(
+            (short.v_init_km_s - long.v_init_km_s).norm() > 1e-3,
+            "direction toggle ignored — short and long-way collapsed: short={:?}, long={:?}",
+            short.v_init_km_s,
+            long.v_init_km_s,
         );
     }
 }

--- a/src/tools/lambert/mod.rs
+++ b/src/tools/lambert/mod.rs
@@ -63,7 +63,7 @@ impl TransferKind {
     ) -> Result<f64, LambertError> {
         match self {
             TransferKind::Auto => {
-                let mut dnu = r_final[1].atan2(r_final[0]) - r_init[1].atan2(r_final[1]);
+                let mut dnu = r_final[1].atan2(r_final[0]) - r_init[1].atan2(r_init[0]);
                 if dnu > TAU {
                     dnu -= TAU;
                 } else if dnu < 0.0 {
@@ -171,5 +171,38 @@ impl LambertSolution {
     /// Returns the c3 computed as the departure v infinity norm squared
     pub fn c3_km2_s2(&self) -> f64 {
         self.v_inf_outgoing_km_s().norm_squared()
+    }
+}
+
+#[cfg(test)]
+mod ut_lambert_transfer_kind {
+    use super::{TransferKind, Vector3};
+
+    #[test]
+    fn test_auto_direction_of_motion_long_way() {
+        // Regression: Δν = 3π/2 (r_init on +x, r_final on -y) must select
+        // the long way (-1.0). The pre-fix expression
+        // `r_init[1].atan2(r_final[1])` yielded the short way (+1.0).
+        let r_init = Vector3::new(8000.0, 0.0, 0.0);
+        let r_final = Vector3::new(0.0, -8000.0, 0.0);
+
+        let dm = TransferKind::Auto
+            .direction_of_motion(&r_final, &r_init)
+            .unwrap();
+
+        assert_eq!(dm, -1.0, "Auto should pick long-way for Δν=3π/2; got {dm}");
+    }
+
+    #[test]
+    fn test_auto_direction_of_motion_short_way() {
+        // Sanity companion: Δν = π/2 (+x → +y) must select short way.
+        let r_init = Vector3::new(8000.0, 0.0, 0.0);
+        let r_final = Vector3::new(0.0, 8000.0, 0.0);
+
+        let dm = TransferKind::Auto
+            .direction_of_motion(&r_final, &r_init)
+            .unwrap();
+
+        assert_eq!(dm, 1.0, "Auto should pick short-way for Δν=π/2; got {dm}");
     }
 }

--- a/src/tools/lambert/mod.rs
+++ b/src/tools/lambert/mod.rs
@@ -64,9 +64,7 @@ impl TransferKind {
         match self {
             TransferKind::Auto => {
                 let mut dnu = r_final[1].atan2(r_final[0]) - r_init[1].atan2(r_init[0]);
-                if dnu > TAU {
-                    dnu -= TAU;
-                } else if dnu < 0.0 {
+                if dnu < 0.0 {
                     dnu += TAU;
                 }
 


### PR DESCRIPTION
## Summary
- **Bug A** — `src/tools/lambert/izzo.rs`: the branch `if i_h.z < 0.0 || retrograde` conflated ECI-frame parity of the angular momentum versor with the user's direction choice, collapsing `ShortWay`/`LongWay`/`Auto` to one solution whenever `(r_init × r_final).z < 0`. Fixed by normalizing `i_h` to point along `+z` up-front (matching the [lamberthub](https://github.com/jorgepiloto/lamberthub/blob/main/src/lamberthub/universal_solvers/izzo.py) reference already cited in the module docstring), so the subsequent branch depends only on the caller's direction flag.
- **Bug B** — `src/tools/lambert/mod.rs`: one-character fix in `TransferKind::Auto::direction_of_motion`. The second `atan2` was `r_init[1].atan2(r_final[1])` — a copy-paste slip of the `nu_init` expression at `src/tools/lambert/godding.rs:57`. Replaced with `r_init[1].atan2(r_init[0])` so `dnu` is the actual sweep angle.

## Tests added
- `test_lambert_izzo_direction_toggle_ih_negative` — Izzo regression: `i_h.z<0` geometry, `ShortWay` vs `LongWay` must differ. Fails before the fix.
- `test_lambert_gooding_direction_toggle_ih_negative` — Gooding symmetry-lock: same invariant on the Gooding path, which was already correct. Pins it so future refactors can't reintroduce the collapse.
- `test_auto_direction_of_motion_long_way` — Δν = 3π/2 must select `-1.0`. Fails before the fix.
- `test_auto_direction_of_motion_short_way` — Sanity companion: Δν = π/2 must select `+1.0`.

## Test plan
- [x] `cargo test -p nyx-space --lib tools::lambert` — 8/8 pass (4 new, 4 pre-existing Vallado unchanged)
- [x] `cargo check --all-features` — clean

Resolves #530