### PR TITLE
fix: fix bls estimator validity and add long arc chunking and cross-arc evaluation

### DIFF
--- a/src/dynamics/sequence/mod.rs
+++ b/src/dynamics/sequence/mod.rs
@@ -23,9 +23,9 @@ use anise::prelude::Almanac;
 use hifitime::{Epoch, Unit};
 use indexmap::IndexMap;
 use log::{debug, info};
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_dhall::{SimpleType, StaticType};
 use snafu::ResultExt;
 use std::collections::HashMap;

--- a/src/dynamics/sequence/python.rs
+++ b/src/dynamics/sequence/python.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "python")]
 use {
-    super::SpacecraftSequence,
-    crate::Spacecraft,
-    anise::almanac::Almanac,
-    pyo3::prelude::*,
+    super::SpacecraftSequence, crate::Spacecraft, anise::almanac::Almanac, pyo3::prelude::*,
     std::sync::Arc,
 };
 
@@ -18,19 +15,23 @@ impl SpacecraftSequence {
     #[classmethod]
     #[pyo3(name = "from_dhall")]
     fn py_from_dhall(_cls: &Bound<'_, pyo3::types::PyType>, dhall_str: &str) -> PyResult<Self> {
-        serde_dhall::from_str(dhall_str).parse().map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        serde_dhall::from_str(dhall_str)
+            .parse()
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     #[classmethod]
     #[pyo3(name = "from_yaml")]
     fn py_from_yaml(_cls: &Bound<'_, pyo3::types::PyType>, yaml_str: &str) -> PyResult<Self> {
-        serde_yml::from_str(yaml_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        serde_yml::from_str(yaml_str)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     #[pyo3(name = "setup")]
     fn py_setup(&mut self, py: Python<'_>, almanac: Py<Almanac>) -> PyResult<()> {
         let almanac_ref = almanac.borrow(py);
-        self.setup(Arc::new(almanac_ref.clone())).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        self.setup(Arc::new(almanac_ref.clone()))
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     #[pyo3(name = "propagate")]
@@ -42,10 +43,14 @@ impl SpacecraftSequence {
         almanac: Py<Almanac>,
     ) -> PyResult<Vec<(Option<String>, Vec<Spacecraft>)>> {
         let almanac_ref = almanac.borrow(py);
-        let trajs = self.propagate(state, until_phase, Arc::new(almanac_ref.clone()))
+        let trajs = self
+            .propagate(state, until_phase, Arc::new(almanac_ref.clone()))
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        let result = trajs.into_iter().map(|traj| (traj.name, traj.states)).collect();
+        let result = trajs
+            .into_iter()
+            .map(|traj| (traj.name, traj.states))
+            .collect();
         Ok(result)
     }
 }

--- a/src/od/blse/mod.rs
+++ b/src/od/blse/mod.rs
@@ -149,7 +149,7 @@ where
         arc: &TrackingDataArc,
     ) -> Result<BLSSolution<D::StateType>, ODError> {
         let measurements = &arc.measurements;
-        let num_measurements = measurements.len();
+        let num_measurements = measurements.values().filter(|m| !m.rejected).count();
         let mut devices = self.devices.clone();
 
         ensure!(
@@ -197,6 +197,9 @@ where
             let mut stm = StateMatrix::<D>::identity();
 
             for (epoch_ref, msr) in measurements.iter() {
+                if msr.rejected {
+                    continue;
+                }
                 let msr_epoch = *epoch_ref;
 
                 loop {
@@ -440,5 +443,100 @@ where
             final_corr_pos_km: corr_pos_km,
             converged,
         })
+    }
+
+    /// Evaluates the RMS of a given state over a tracking data arc without performing any estimation.
+    /// This is useful to check that a given solution is consistent across overlapping or disjoint data arcs.
+    pub fn evaluate(
+        &self,
+        state: D::StateType,
+        arc: &TrackingDataArc,
+    ) -> Result<f64, ODError> {
+        let measurements = &arc.measurements;
+        let num_measurements = measurements.values().filter(|m| !m.rejected).count();
+        let mut devices = self.devices.clone();
+
+        ensure!(
+            num_measurements >= 1,
+            TooFewMeasurementsSnafu {
+                need: 1_usize,
+                action: "BLSE Evaluate"
+            }
+        );
+
+        let mut sum_sq_weighted_residuals = 0.0;
+        let mut unknown_trackers = IndexSet::new();
+
+        let mut prop_inst = self.prop.with(state.with_stm(), self.almanac.clone()).quiet();
+        let mut epoch = state.epoch();
+
+        for (epoch_ref, msr) in measurements.iter() {
+            if msr.rejected {
+                continue;
+            }
+            let msr_epoch = *epoch_ref;
+
+            loop {
+                let delta_t = msr_epoch - epoch;
+                if delta_t <= Duration::ZERO {
+                    break;
+                }
+
+                let next_step = delta_t.min(prop_inst.step_size).min(self.max_step);
+                let this_state = prop_inst.for_duration(next_step).context(ODPropSnafu)?;
+                epoch = this_state.epoch();
+
+                if (epoch - msr_epoch).abs() < self.epoch_precision {
+                    let device = match devices.get_mut(&msr.tracker) {
+                        Some(d) => d,
+                        None => {
+                            if !unknown_trackers.contains(&msr.tracker) {
+                                error!(
+                                    "Tracker {} is not in the list of configured devices",
+                                    msr.tracker
+                                );
+                            }
+                            unknown_trackers.insert(msr.tracker.clone());
+                            continue;
+                        }
+                    };
+
+                    for msr_type in msr.data.keys().copied() {
+                        let mut msr_types = IndexSet::new();
+                        msr_types.insert(msr_type);
+
+                        let computed_meas_opt = device
+                            .measure_instantaneous(this_state, None, self.almanac.clone())?;
+
+                        let computed_meas = match computed_meas_opt {
+                            Some(cm) => cm,
+                            None => continue,
+                        };
+
+                        let computed_obs = computed_meas.observation::<U1>(&msr_types)[0];
+                        let real_obs = msr.observation::<U1>(&msr_types)[0];
+
+                        ensure!(
+                            real_obs.is_finite(),
+                            InvalidMeasurementSnafu {
+                                epoch: msr_epoch,
+                                val: real_obs
+                            }
+                        );
+
+                        let residual = real_obs - computed_obs;
+                        let r_matrix = device.measurement_covar_matrix::<U1>(&msr_types, msr_epoch)?;
+                        let r_variance = r_matrix[(0, 0)];
+
+                        ensure!(r_variance > 0.0, SingularNoiseRkSnafu);
+                        let weight = 1.0 / r_variance;
+
+                        sum_sq_weighted_residuals += weight * residual * residual;
+                    }
+                }
+            }
+        }
+
+        Ok((sum_sq_weighted_residuals / num_measurements as f64).sqrt())
     }
 }

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -401,6 +401,49 @@ impl TrackingDataArc {
         self.force_reject = true;
         self
     }
+
+    /// Splits a long tracking data arc into smaller chunks, each up to `max_duration` long.
+    /// This is inspired by JPL MONTE's long arc setup to ensure BLSE convergence on manageable chunks.
+    pub fn chunk(&self, max_duration: Duration) -> Vec<TrackingDataArc> {
+        let mut chunks = Vec::new();
+        if self.is_empty() {
+            return chunks;
+        }
+
+        let mut current_chunk = TrackingDataArc {
+            source: self.source.clone(),
+            moduli: self.moduli.clone(),
+            force_reject: self.force_reject,
+            ..Default::default()
+        };
+
+        let mut chunk_start_epoch = self.start_epoch().unwrap();
+
+        for (epoch, msr) in &self.measurements {
+            if *epoch - chunk_start_epoch > max_duration {
+                // Save current chunk and start a new one
+                if !current_chunk.is_empty() {
+                    chunks.push(current_chunk);
+                }
+                current_chunk = TrackingDataArc {
+                    source: self.source.clone(),
+                    moduli: self.moduli.clone(),
+                    force_reject: self.force_reject,
+                    ..Default::default()
+                };
+                chunk_start_epoch = *epoch;
+            }
+            current_chunk.measurements.insert(*epoch, msr.clone());
+        }
+
+        // Add the last chunk
+        if !current_chunk.is_empty() {
+            chunks.push(current_chunk);
+        }
+
+        chunks
+    }
+
 }
 
 impl fmt::Display for TrackingDataArc {

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -410,35 +410,27 @@ impl TrackingDataArc {
             return chunks;
         }
 
-        let mut current_chunk = TrackingDataArc {
-            source: self.source.clone(),
-            moduli: self.moduli.clone(),
-            force_reject: self.force_reject,
-            ..Default::default()
-        };
+        let end_epoch = self.end_epoch().unwrap();
+        let mut chunk_start = self.start_epoch().unwrap();
 
-        let mut chunk_start_epoch = self.start_epoch().unwrap();
-
-        for (epoch, msr) in &self.measurements {
-            if *epoch - chunk_start_epoch > max_duration {
-                // Save current chunk and start a new one
-                if !current_chunk.is_empty() {
-                    chunks.push(current_chunk);
-                }
-                current_chunk = TrackingDataArc {
-                    source: self.source.clone(),
-                    moduli: self.moduli.clone(),
-                    force_reject: self.force_reject,
-                    ..Default::default()
-                };
-                chunk_start_epoch = *epoch;
+        while chunk_start <= end_epoch {
+            let chunk_end = chunk_start + max_duration;
+            let sub_arc = self.clone().filter_by_epoch(chunk_start..chunk_end);
+            if !sub_arc.is_empty() {
+                chunks.push(sub_arc);
             }
-            current_chunk.measurements.insert(*epoch, msr.clone());
-        }
-
-        // Add the last chunk
-        if !current_chunk.is_empty() {
-            chunks.push(current_chunk);
+            // Move start to the next measurement's epoch after chunk_end
+            let mut found_next = false;
+            for (epoch, _) in self.measurements.range(chunk_end..) {
+                if *epoch >= chunk_end {
+                    chunk_start = *epoch;
+                    found_next = true;
+                    break;
+                }
+            }
+            if !found_next {
+                break;
+            }
         }
 
         chunks

--- a/src/od/msr/trackingdata/mod.rs
+++ b/src/od/msr/trackingdata/mod.rs
@@ -435,7 +435,6 @@ impl TrackingDataArc {
 
         chunks
     }
-
 }
 
 impl fmt::Display for TrackingDataArc {

--- a/tests/orbit_determination/blse.rs
+++ b/tests/orbit_determination/blse.rs
@@ -136,6 +136,19 @@ fn blse_robust_large_disp(
         .almanac(almanac.clone())
         .build();
 
+    let this_arc = &arc.filter_by_offset(..offset);
+
+    let initial_rms = blse
+        .evaluate(
+            if disperse {
+                initial_estimate.nominal_state
+            } else {
+                initial_state
+            },
+            &this_arc,
+        )
+        .unwrap();
+
     let blse_solution = blse
         .estimate(
             if disperse {
@@ -143,7 +156,7 @@ fn blse_robust_large_disp(
             } else {
                 initial_state
             },
-            &arc.filter_by_offset(..offset),
+            this_arc,
         )
         .expect("blse should not fail");
 
@@ -183,4 +196,17 @@ fn blse_robust_large_disp(
 
     let kf_est: KfEstimate<Spacecraft> = blse_solution.into();
     println!("{kf_est}");
+
+    let final_rms = blse.evaluate(kf_est.state(), &this_arc).unwrap();
+    println!(
+        "[disp={disperse}] Final RMS = {final_rms}\tInitial RMS = {initial_rms}\tBetter? {}",
+        final_rms <= initial_rms
+    );
+
+    if disperse {
+        assert!(
+            final_rms <= initial_rms,
+            "BLSE failed to find a better solution"
+        );
+    }
 }


### PR DESCRIPTION
This pull request addresses several functional improvements and validitiy issues in the Batch Least Squares (BLS) estimator:
1. **Fix Validity Issue**: The `estimate` function in `BatchLeastSquares` now correctly respects the `rejected` flag on measurements, preventing them from corrupting the normal matrix and RMS calculation. The RMS is correctly scaled by the actual number of accepted measurements.
2. **Support Overlapping Arcs / Consistency Check**: Added a new `evaluate` method to `BatchLeastSquares`. This runs exactly one pass computing the residuals and RMS of a given state over an arbitrary `TrackingDataArc` without attempting estimation, which allows validating a solution's consistency across disjoint or overlapping data arcs.
3. **Simplify Long Arc Setup**: Inspired by JPL MONTE, added a `chunk(max_duration)` method to `TrackingDataArc` that makes it easy to automatically split extremely long tracking arcs into manageable chunks to improve BLS convergence.

---
*PR created automatically by Jules for task [2131282322621648286](https://jules.google.com/task/2131282322621648286) started by @ChristopherRabotin*