### PR TITLE
Support CCSDS TDM Frequency rate data

### DIFF
--- a/src/od/interlink/sensitivity.rs
+++ b/src/od/interlink/sensitivity.rs
@@ -162,6 +162,7 @@ impl ScalarSensitivityT<Spacecraft, Spacecraft, InterlinkTxSpacecraft>
             | MeasurementType::Elevation
             | MeasurementType::ReceiveFrequency
             | MeasurementType::TransmitFrequency
+            | MeasurementType::TransmitFrequencyRate
             | MeasurementType::X
             | MeasurementType::Y
             | MeasurementType::Z => Err(ODError::MeasurementSimError {

--- a/src/od/msr/sensitivity.rs
+++ b/src/od/msr/sensitivity.rs
@@ -227,11 +227,9 @@ impl ScalarSensitivityT<Spacecraft, Spacecraft, GroundStation>
             }
             MeasurementType::ReceiveFrequency
             | MeasurementType::TransmitFrequency
-            | MeasurementType::TransmitFrequencyRate => {
-                Err(ODError::MeasurementSimError {
-                    details: format!("{msr_type:?} is only supported in CCSDS TDM parsing"),
-                })
-            }
+            | MeasurementType::TransmitFrequencyRate => Err(ODError::MeasurementSimError {
+                details: format!("{msr_type:?} is only supported in CCSDS TDM parsing"),
+            }),
             MeasurementType::X | MeasurementType::Y | MeasurementType::Z => {
                 Err(ODError::MeasurementSimError {
                     details: format!("{msr_type:?} is not supported for ground stations"),

--- a/src/od/msr/sensitivity.rs
+++ b/src/od/msr/sensitivity.rs
@@ -225,7 +225,9 @@ impl ScalarSensitivityT<Spacecraft, Spacecraft, GroundStation>
                     _tx: PhantomData::<_>,
                 })
             }
-            MeasurementType::ReceiveFrequency | MeasurementType::TransmitFrequency => {
+            MeasurementType::ReceiveFrequency
+            | MeasurementType::TransmitFrequency
+            | MeasurementType::TransmitFrequencyRate => {
                 Err(ODError::MeasurementSimError {
                     details: format!("{msr_type:?} is only supported in CCSDS TDM parsing"),
                 })

--- a/src/od/msr/trackingdata/io_ccsds_tdm.rs
+++ b/src/od/msr/trackingdata/io_ccsds_tdm.rs
@@ -22,8 +22,7 @@ use crate::io::{InputOutputError, StdIOSnafu};
 use crate::od::msr::{Measurement, MeasurementType};
 use anise::constants::SPEED_OF_LIGHT_KM_S;
 use hifitime::efmt::{Format, Formatter};
-use hifitime::prelude::Epoch;
-use hifitime::TimeScale;
+use hifitime::{Duration, Epoch, TimeScale};
 use indexmap::{IndexMap, IndexSet};
 use log::{error, info, warn};
 use snafu::ResultExt;
@@ -63,7 +62,7 @@ impl TrackingDataArc {
     ///
     /// ### Time systems / time scales
     ///
-    /// All timescales supported by hifitime are supported here. This includes: UTC, TAI, GPS, TT, TDB, TAI, GST, QZSST.
+    /// All timescales supported by hifitime are supported here. This includes: UTC, TAI, GPS, TT, TDB, TAI, GST, QZSST, TL, TCL.
     ///
     /// ### Path
     ///
@@ -201,11 +200,13 @@ impl TrackingDataArc {
                             info!("turn-around ratio is {ta_num}/{ta_denom}");
                             drop_freq_data = false;
                         } else {
-                            error!("turn-around denominator `{ta_denom_str}` is not a valid double precision float");
+                            error!(
+                                "turn-around denominator `{ta_denom_str}` is not a valid integer"
+                            );
                             drop_freq_data = true;
                         }
                     } else {
-                        error!("turn-around numerator `{ta_num_str}` is not a valid double precision float");
+                        error!("turn-around numerator `{ta_num_str}` is not a valid integer");
                         drop_freq_data = true;
                     }
                 } else {
@@ -278,9 +279,13 @@ impl TrackingDataArc {
             }
 
             // Update the transmit frequency and rate if they are set.
-            if let Some(rate) = measurement.data.get(&MeasurementType::TransmitFrequencyRate) {
-                if let (Some(last_f), Some(last_e)) = (latest_transmit_freq, latest_transmit_epoch) {
-                    let dt: hifitime::Duration = *epoch - last_e;
+            if let Some(rate) = measurement
+                .data
+                .get(&MeasurementType::TransmitFrequencyRate)
+            {
+                if let (Some(last_f), Some(last_e)) = (latest_transmit_freq, latest_transmit_epoch)
+                {
+                    let dt: Duration = *epoch - last_e;
                     latest_transmit_freq = Some(last_f + latest_transmit_rate * dt.to_seconds());
                 }
                 latest_transmit_epoch = Some(*epoch);
@@ -292,16 +297,19 @@ impl TrackingDataArc {
                 latest_transmit_epoch = Some(*epoch);
             }
 
-            if !measurement.data.contains_key(&MeasurementType::ReceiveFrequency) {
-                // If there's no receive frequency, we just continue (having updated the transmit freq/rate)
-                // but we must remove the transmit freq/rate from the measurement.
+            if !measurement
+                .data
+                .contains_key(&MeasurementType::ReceiveFrequency)
+            {
+                // If there's no receive frequency, we just continue (having updated the transmit freq rate)
+                // but we must remove the transmit freq rate from the measurement.
                 for freq in &freq_types {
                     measurement.data.swap_remove(freq);
                 }
                 continue;
             }
 
-            // We have a receive frequency!
+            // There is a receive frequency
             if latest_transmit_freq.is_none() {
                 warn!("receive frequency found at {epoch} but no transmit frequency was ever set, ignoring");
                 for freq in &freq_types {
@@ -310,8 +318,10 @@ impl TrackingDataArc {
                 continue;
             }
 
-            let dt: hifitime::Duration = *epoch - latest_transmit_epoch.unwrap();
-            let transmit_freq_hz = latest_transmit_freq.unwrap() + latest_transmit_rate * dt.to_seconds();
+            let dt: Duration = *epoch - latest_transmit_epoch.unwrap();
+            let transmit_freq_hz =
+                latest_transmit_freq.unwrap() + latest_transmit_rate * dt.to_seconds();
+
             let receive_freq_hz = *measurement
                 .data
                 .get(&MeasurementType::ReceiveFrequency)
@@ -355,7 +365,7 @@ impl TrackingDataArc {
             None
         };
 
-        // Filter out any measurements that have no data left.
+        // Remove measurements that have no data left after our processing.
         measurements.retain(|_, m| !m.data.is_empty());
 
         let trk = Self {
@@ -593,10 +603,12 @@ fn parse_measurement_line(
         | "RECEIVE_FREQ_4" | "RECEIVE_FREQ_5" => MeasurementType::ReceiveFrequency,
         "TRANSMIT_FREQ" | "TRANSMIT_FREQ_1" | "TRANSMIT_FREQ_2" | "TRANSMIT_FREQ_3"
         | "TRANSMIT_FREQ_4" | "TRANSMIT_FREQ_5" => MeasurementType::TransmitFrequency,
-        "TRANSMIT_FREQ_RATE" | "TRANSMIT_FREQ_RATE_1" | "TRANSMIT_FREQ_RATE_2"
-        | "TRANSMIT_FREQ_RATE_3" | "TRANSMIT_FREQ_RATE_4" | "TRANSMIT_FREQ_RATE_5" => {
-            MeasurementType::TransmitFrequencyRate
-        }
+        "TRANSMIT_FREQ_RATE"
+        | "TRANSMIT_FREQ_RATE_1"
+        | "TRANSMIT_FREQ_RATE_2"
+        | "TRANSMIT_FREQ_RATE_3"
+        | "TRANSMIT_FREQ_RATE_4"
+        | "TRANSMIT_FREQ_RATE_5" => MeasurementType::TransmitFrequencyRate,
         _ => {
             return Err(InputOutputError::UnsupportedData {
                 which: mtype_str.to_string(),

--- a/src/od/msr/trackingdata/io_ccsds_tdm.rs
+++ b/src/od/msr/trackingdata/io_ccsds_tdm.rs
@@ -167,6 +167,7 @@ impl TrackingDataArc {
                 if [
                     MeasurementType::ReceiveFrequency,
                     MeasurementType::TransmitFrequency,
+                    MeasurementType::TransmitFrequencyRate,
                 ]
                 .contains(&mtype)
                 {
@@ -237,9 +238,11 @@ impl TrackingDataArc {
         let mut freq_types = IndexSet::new();
         freq_types.insert(MeasurementType::ReceiveFrequency);
         freq_types.insert(MeasurementType::TransmitFrequency);
+        freq_types.insert(MeasurementType::TransmitFrequencyRate);
 
         let mut latest_transmit_freq = None;
-        let mut malformed_warning = 0;
+        let mut latest_transmit_epoch = None;
+        let mut latest_transmit_rate = 0.0;
 
         let mut all_applied_corrections = IndexSet::new();
 
@@ -253,6 +256,7 @@ impl TrackingDataArc {
                     MeasurementType::Elevation,
                     MeasurementType::ReceiveFrequency,
                     MeasurementType::TransmitFrequency,
+                    MeasurementType::TransmitFrequencyRate,
                 ] {
                     let kw = format!("CORRECTION_{}", msr_type.ccsds_tdm_name());
                     if let Some(correction_str) = metadata.get(&kw) {
@@ -273,55 +277,41 @@ impl TrackingDataArc {
                 continue;
             }
 
-            let avail = measurement.availability(&freq_types);
-            let use_prev_transmit_freq: bool;
-            let num_freq_msr = avail
-                .iter()
-                .copied()
-                .map(|v| if v { 1 } else { 0 })
-                .sum::<u8>();
-            if num_freq_msr == 0 {
-                // No frequency measurements
-                continue;
-            } else if num_freq_msr == 1 {
-                // avail[0] means that Receive Freq is available
-                // avail[1] means that Transmit Freq is available
-                // We can only compute Doppler data from one data point if that data point
-                // if the receive frequency and the transmit frequency was previously set.
-                if let Some(latest_transmit_freq) = latest_transmit_freq {
-                    if avail[0] {
-                        use_prev_transmit_freq = true;
-                        if malformed_warning == 0 {
-                            warn!(
-                                "no transmit frequency at {epoch}, using {latest_transmit_freq} Hz",
-                            );
-                        }
-                        malformed_warning += 1;
-                    } else {
-                        use_prev_transmit_freq = false;
-                    }
-                } else {
-                    warn!("only one of receive or transmit frequencies found at {epoch}, ignoring");
-                    for freq in &freq_types {
-                        measurement.data.swap_remove(freq);
-                    }
-                    continue;
+            // Update the transmit frequency and rate if they are set.
+            if let Some(rate) = measurement.data.get(&MeasurementType::TransmitFrequencyRate) {
+                if let (Some(last_f), Some(last_e)) = (latest_transmit_freq, latest_transmit_epoch) {
+                    let dt: hifitime::Duration = *epoch - last_e;
+                    latest_transmit_freq = Some(last_f + latest_transmit_rate * dt.to_seconds());
                 }
-            } else {
-                use_prev_transmit_freq = false;
+                latest_transmit_epoch = Some(*epoch);
+                latest_transmit_rate = *rate;
             }
 
-            if !use_prev_transmit_freq {
-                // Update the latest transmit frequency since it's set.
-                latest_transmit_freq = Some(
-                    *measurement
-                        .data
-                        .get(&MeasurementType::TransmitFrequency)
-                        .unwrap(),
-                );
+            if let Some(freq) = measurement.data.get(&MeasurementType::TransmitFrequency) {
+                latest_transmit_freq = Some(*freq);
+                latest_transmit_epoch = Some(*epoch);
             }
 
-            let transmit_freq_hz = latest_transmit_freq.unwrap();
+            if !measurement.data.contains_key(&MeasurementType::ReceiveFrequency) {
+                // If there's no receive frequency, we just continue (having updated the transmit freq/rate)
+                // but we must remove the transmit freq/rate from the measurement.
+                for freq in &freq_types {
+                    measurement.data.swap_remove(freq);
+                }
+                continue;
+            }
+
+            // We have a receive frequency!
+            if latest_transmit_freq.is_none() {
+                warn!("receive frequency found at {epoch} but no transmit frequency was ever set, ignoring");
+                for freq in &freq_types {
+                    measurement.data.swap_remove(freq);
+                }
+                continue;
+            }
+
+            let dt: hifitime::Duration = *epoch - latest_transmit_epoch.unwrap();
+            let transmit_freq_hz = latest_transmit_freq.unwrap() + latest_transmit_rate * dt.to_seconds();
             let receive_freq_hz = *measurement
                 .data
                 .get(&MeasurementType::ReceiveFrequency)
@@ -340,10 +330,6 @@ impl TrackingDataArc {
             measurement
                 .data
                 .insert(MeasurementType::Doppler, rho_dot_km_s);
-        }
-
-        if malformed_warning > 1 {
-            warn!("missing transmit frequency warning occured {malformed_warning} times",);
         }
 
         if !all_applied_corrections.is_empty() {
@@ -368,6 +354,9 @@ impl TrackingDataArc {
         } else {
             None
         };
+
+        // Filter out any measurements that have no data left.
+        measurements.retain(|_, m| !m.data.is_empty());
 
         let trk = Self {
             measurements,
@@ -604,6 +593,10 @@ fn parse_measurement_line(
         | "RECEIVE_FREQ_4" | "RECEIVE_FREQ_5" => MeasurementType::ReceiveFrequency,
         "TRANSMIT_FREQ" | "TRANSMIT_FREQ_1" | "TRANSMIT_FREQ_2" | "TRANSMIT_FREQ_3"
         | "TRANSMIT_FREQ_4" | "TRANSMIT_FREQ_5" => MeasurementType::TransmitFrequency,
+        "TRANSMIT_FREQ_RATE" | "TRANSMIT_FREQ_RATE_1" | "TRANSMIT_FREQ_RATE_2"
+        | "TRANSMIT_FREQ_RATE_3" | "TRANSMIT_FREQ_RATE_4" | "TRANSMIT_FREQ_RATE_5" => {
+            MeasurementType::TransmitFrequencyRate
+        }
         _ => {
             return Err(InputOutputError::UnsupportedData {
                 which: mtype_str.to_string(),

--- a/src/od/msr/types.rs
+++ b/src/od/msr/types.rs
@@ -101,11 +101,11 @@ impl MeasurementType {
             Self::Doppler => Ok(aer.range_rate_km_s + noise),
             Self::Azimuth => Ok(aer.azimuth_deg + noise),
             Self::Elevation => Ok(aer.elevation_deg + noise),
-            Self::ReceiveFrequency
-            | Self::TransmitFrequency
-            | Self::TransmitFrequencyRate => Err(ODError::MeasurementSimError {
-                details: format!("{self:?} is only supported in CCSDS TDM parsing"),
-            }),
+            Self::ReceiveFrequency | Self::TransmitFrequency | Self::TransmitFrequencyRate => {
+                Err(ODError::MeasurementSimError {
+                    details: format!("{self:?} is only supported in CCSDS TDM parsing"),
+                })
+            }
             Self::X | Self::Y | Self::Z => Err(ODError::MeasurementSimError {
                 details: format!("{self:?} must be computed directly from the state"),
             }),
@@ -137,11 +137,11 @@ impl MeasurementType {
                 let el_deg = (aer_t1.elevation_deg + aer_t0.elevation_deg) * 0.5;
                 Ok(el_deg + noise / 2.0_f64.sqrt())
             }
-            Self::ReceiveFrequency
-            | Self::TransmitFrequency
-            | Self::TransmitFrequencyRate => Err(ODError::MeasurementSimError {
-                details: format!("{self:?} is only supported in CCSDS TDM parsing"),
-            }),
+            Self::ReceiveFrequency | Self::TransmitFrequency | Self::TransmitFrequencyRate => {
+                Err(ODError::MeasurementSimError {
+                    details: format!("{self:?} is only supported in CCSDS TDM parsing"),
+                })
+            }
             Self::X | Self::Y | Self::Z => Err(ODError::MeasurementSimError {
                 details: format!("{self:?} is not supported for two way measurements"),
             }),

--- a/src/od/msr/types.rs
+++ b/src/od/msr/types.rs
@@ -42,6 +42,8 @@ pub enum MeasurementType {
     ReceiveFrequency = 4,
     #[serde(rename = "transmit_freq")]
     TransmitFrequency = 5,
+    #[serde(rename = "transmit_freq_rate")]
+    TransmitFrequencyRate = 9,
     #[serde(rename = "x")]
     X = 6,
     #[serde(rename = "y")]
@@ -58,6 +60,7 @@ impl MeasurementType {
             Self::Doppler => "km/s",
             Self::Azimuth | Self::Elevation => "deg",
             Self::ReceiveFrequency | Self::TransmitFrequency => "Hz",
+            Self::TransmitFrequencyRate => "Hz/s",
             Self::X | Self::Y | Self::Z => "km",
         }
     }
@@ -70,6 +73,7 @@ impl MeasurementType {
             | MeasurementType::Elevation
             | MeasurementType::ReceiveFrequency
             | MeasurementType::TransmitFrequency
+            | MeasurementType::TransmitFrequencyRate
             | MeasurementType::X
             | MeasurementType::Y
             | MeasurementType::Z => false,
@@ -97,7 +101,9 @@ impl MeasurementType {
             Self::Doppler => Ok(aer.range_rate_km_s + noise),
             Self::Azimuth => Ok(aer.azimuth_deg + noise),
             Self::Elevation => Ok(aer.elevation_deg + noise),
-            Self::ReceiveFrequency | Self::TransmitFrequency => Err(ODError::MeasurementSimError {
+            Self::ReceiveFrequency
+            | Self::TransmitFrequency
+            | Self::TransmitFrequencyRate => Err(ODError::MeasurementSimError {
                 details: format!("{self:?} is only supported in CCSDS TDM parsing"),
             }),
             Self::X | Self::Y | Self::Z => Err(ODError::MeasurementSimError {
@@ -131,7 +137,9 @@ impl MeasurementType {
                 let el_deg = (aer_t1.elevation_deg + aer_t0.elevation_deg) * 0.5;
                 Ok(el_deg + noise / 2.0_f64.sqrt())
             }
-            Self::ReceiveFrequency | Self::TransmitFrequency => Err(ODError::MeasurementSimError {
+            Self::ReceiveFrequency
+            | Self::TransmitFrequency
+            | Self::TransmitFrequencyRate => Err(ODError::MeasurementSimError {
                 details: format!("{self:?} is only supported in CCSDS TDM parsing"),
             }),
             Self::X | Self::Y | Self::Z => Err(ODError::MeasurementSimError {
@@ -149,6 +157,7 @@ impl MeasurementType {
             MeasurementType::Elevation => "ANGLE_2",
             MeasurementType::ReceiveFrequency => "RECEIVE_FREQ",
             MeasurementType::TransmitFrequency => "TRANSMIT_FREQ",
+            MeasurementType::TransmitFrequencyRate => "TRANSMIT_FREQ_RATE",
             MeasurementType::X => "X",
             MeasurementType::Y => "Y",
             MeasurementType::Z => "Z",

--- a/tests/tdm_ramp.rs
+++ b/tests/tdm_ramp.rs
@@ -24,9 +24,7 @@ DATA_START
 DATA_STOP
 "#;
 
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("target");
-    path.push("test_ramp.tdm");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test_ramp.tdm");
 
     // Ensure directory exists
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -41,9 +39,15 @@ DATA_STOP
     assert_eq!(arc.len(), 1);
     let (epoch, msr) = arc.measurements.iter().next().unwrap();
 
-    assert_eq!(*epoch, Epoch::from_gregorian_utc(2023, 2, 22, 19, 18, 27, 160_000_000));
+    assert_eq!(
+        *epoch,
+        Epoch::from_gregorian_utc(2023, 2, 22, 19, 18, 27, 160_000_000)
+    );
 
-    let doppler = msr.data.get(&MeasurementType::Doppler).expect("Doppler measurement missing");
+    let doppler = msr
+        .data
+        .get(&MeasurementType::Doppler)
+        .expect("Doppler measurement missing");
 
     // Expected calculation:
     // T0 = 19:18:17.160, F0 = 2.1e9, R0 = 1.0
@@ -58,5 +62,8 @@ DATA_STOP
     // rho_dot = (1524.127089 * 299792.458) / (2 * 2280543002.714932) = 0.1001782921
 
     let expected_rho_dot = 0.1001782921;
-    assert!((doppler - expected_rho_dot).abs() < 1e-8, "Doppler value mismatch: got {}, expected {}", doppler, expected_rho_dot);
+    assert!(
+        (doppler - expected_rho_dot).abs() < 1e-8,
+        "Doppler value mismatch: got {doppler}, expected {expected_rho_dot}",
+    );
 }

--- a/tests/tdm_ramp.rs
+++ b/tests/tdm_ramp.rs
@@ -1,0 +1,62 @@
+use hifitime::prelude::*;
+use nyx_space::od::msr::{MeasurementType, TrackingDataArc};
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[test]
+fn test_tdm_frequency_ramp() {
+    let tdm_content = r#"CCSDS_TDM_VERS = 2.0
+META_START
+  TIME_SYSTEM = UTC
+  PARTICIPANT_1 = DSS14
+  PARTICIPANT_2 = MySpacecraft
+  MODE = SEQUENTIAL
+  PATH = 1,2,1
+  TURNAROUND_NUMERATOR = 240
+  TURNAROUND_DENOMINATOR = 221
+META_STOP
+DATA_START
+  TRANSMIT_FREQ      = 2023-02-22T19:18:17.160 2100000000.0
+  TRANSMIT_FREQ_RATE = 2023-02-22T19:18:17.160 1.0
+  TRANSMIT_FREQ_RATE = 2023-02-22T19:18:22.160 2.0
+  RECEIVE_FREQ       = 2023-02-22T19:18:27.160 2280541478.587843
+DATA_STOP
+"#;
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target");
+    path.push("test_ramp.tdm");
+
+    // Ensure directory exists
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+    let mut file = File::create(&path).unwrap();
+    file.write_all(tdm_content.as_bytes()).unwrap();
+
+    let arc = TrackingDataArc::from_tdm(&path, None).unwrap();
+
+    println!("{arc}");
+
+    assert_eq!(arc.len(), 1);
+    let (epoch, msr) = arc.measurements.iter().next().unwrap();
+
+    assert_eq!(*epoch, Epoch::from_gregorian_utc(2023, 2, 22, 19, 18, 27, 160_000_000));
+
+    let doppler = msr.data.get(&MeasurementType::Doppler).expect("Doppler measurement missing");
+
+    // Expected calculation:
+    // T0 = 19:18:17.160, F0 = 2.1e9, R0 = 1.0
+    // T1 = 19:18:22.160, R1 = 2.0
+    // F(T1) = F0 + R0 * (T1 - T0) = 2.1e9 + 1.0 * 5 = 2100000005.0
+    // T2 = 19:18:27.160, FR2 = 2280541478.587843
+    // F(T2) = F(T1) + R1 * (T2 - T1) = 2100000005.0 + 2.0 * 5 = 2100000015.0
+    // k = 240/221
+    // f_t_expected = F(T2) * k = 2100000015.0 * 240 / 221 = 2280543002.714932
+    // doppler_shift = f_t_expected - FR2 = 2280543002.714932 - 2280541478.587843 = 1524.127089
+    // rho_dot = (doppler_shift * c) / (2 * f_t_expected)
+    // rho_dot = (1524.127089 * 299792.458) / (2 * 2280543002.714932) = 0.1001782921
+
+    let expected_rho_dot = 0.1001782921;
+    assert!((doppler - expected_rho_dot).abs() < 1e-8, "Doppler value mismatch: got {}, expected {}", doppler, expected_rho_dot);
+}


### PR DESCRIPTION
Supported `TRANSMIT_FREQ_RATE` in CCSDS TDM parsing to allow processing of frequency ramps. This includes adding a new measurement type, updating the parser to maintain a piecewise linear frequency model, and adding an integration test.

Fixes #539

---
*PR created automatically by Jules for task [17510717920801124048](https://jules.google.com/task/17510717920801124048) started by @ChristopherRabotin*