### PR TITLE
Use &Almanac instead of Arc<Almanac> in dynamics traits

### DIFF
--- a/nyx-core/src/cosmic/eclipse.rs
+++ b/nyx-core/src/cosmic/eclipse.rs
@@ -26,7 +26,6 @@ use serde_dhall::StaticType;
 
 pub use super::{Frame, Orbit, Spacecraft};
 use std::fmt;
-use std::sync::Arc;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -57,7 +56,7 @@ impl fmt::Display for ShadowModel {
 impl ShadowModel {
     /// Creates a new typical eclipse locator.
     /// The light source is the Sun, and the shadow bodies are the Earth and the Moon.
-    pub fn cislunar(almanac: Arc<Almanac>) -> Self {
+    pub fn cislunar(almanac: &Almanac) -> Self {
         let eme2k = almanac.frame_info(EARTH_J2000).unwrap();
         let moon_j2k = almanac.frame_info(MOON_J2000).unwrap();
         Self {
@@ -67,7 +66,7 @@ impl ShadowModel {
     }
 
     /// Compute the visibility/eclipse between an observer and an observed state
-    pub fn compute(&self, observer: Orbit, almanac: Arc<Almanac>) -> AlmanacResult<Occultation> {
+    pub fn compute(&self, observer: Orbit, almanac: &Almanac) -> AlmanacResult<Occultation> {
         let mut state = Occultation {
             epoch: observer.epoch,
             back_frame: SUN_J2000,

--- a/nyx-core/src/dynamics/drag.rs
+++ b/nyx-core/src/dynamics/drag.rs
@@ -87,7 +87,7 @@ impl ForceModel for ConstantDrag {
         if self.estimate { Some(7) } else { None }
     }
 
-    fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
+    fn eom(&self, ctx: &Spacecraft, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
         let osc =
             almanac
                 .transform_to(ctx.orbit, self.frame, None)
@@ -109,7 +109,7 @@ impl ForceModel for ConstantDrag {
     fn gradient(
         &self,
         _osc_ctx: &Spacecraft,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError> {
         Err(DynamicsError::DynamicsAstro {
             source: AstroError::PartialsUndefined,
@@ -178,7 +178,7 @@ impl ForceModel for Drag {
         if self.estimate { Some(7) } else { None }
     }
 
-    fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
+    fn eom(&self, ctx: &Spacecraft, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
         let integration_frame = ctx.orbit.frame;
 
         let osc_drag_frame =
@@ -286,7 +286,7 @@ impl ForceModel for Drag {
     fn gradient(
         &self,
         _osc_ctx: &Spacecraft,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError> {
         Err(DynamicsError::DynamicsAstro {
             source: AstroError::PartialsUndefined,

--- a/nyx-core/src/dynamics/gravity_field.rs
+++ b/nyx-core/src/dynamics/gravity_field.rs
@@ -145,7 +145,7 @@ impl fmt::Display for GravityField {
 }
 
 impl AccelModel for GravityField {
-    fn eom(&self, osc: &Orbit, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
+    fn eom(&self, osc: &Orbit, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
         // Convert the osculating orbit to the correct frame (needed for multiple harmonic fields)
         let state = almanac
             .transform_to(*osc, self.grav_data.frame, None)
@@ -273,7 +273,7 @@ impl AccelModel for GravityField {
     fn gradient(
         &self,
         osc: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError> {
         // Convert the osculating orbit to the correct frame (needed for multiple harmonic fields)
         let state = almanac

--- a/nyx-core/src/dynamics/guidance/kluever.rs
+++ b/nyx-core/src/dynamics/guidance/kluever.rs
@@ -296,12 +296,12 @@ impl GuidanceLaw for Kluever {
     }
 
     /// Update the state for the next iteration
-    fn next(&self, sc: &mut Spacecraft, almanac: Arc<Almanac>) {
+    fn next(&self, sc: &mut Spacecraft, almanac: &Almanac) {
         if sc.mode() != GuidanceMode::Inhibit {
             if !self.achieved(sc).unwrap() {
                 // Check eclipse state if applicable.
                 if let Some(max_eclipse) = self.max_eclipse_prct {
-                    let locator = ShadowModel::cislunar(almanac.clone());
+                    let locator = ShadowModel::cislunar(almanac);
                     if locator
                         .compute(sc.orbit, almanac)
                         .expect("cannot compute eclipse")

--- a/nyx-core/src/dynamics/guidance/mnvr.rs
+++ b/nyx-core/src/dynamics/guidance/mnvr.rs
@@ -32,7 +32,6 @@ use serde_dhall::{SimpleType, StaticType};
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
 
 /// Impulsive maneuver defines an instantaneous state change which causes a discontinuity in the trajectory.
 /// While useful for preliminary design, it is not typically relevant for spaceflight operations
@@ -386,7 +385,7 @@ impl GuidanceLaw for Maneuver {
         }
     }
 
-    fn next(&self, sc: &mut Spacecraft, _almanac: Arc<Almanac>) {
+    fn next(&self, sc: &mut Spacecraft, _almanac: &Almanac) {
         let next_mode = if sc.epoch() >= self.start && sc.epoch() <= self.end {
             GuidanceMode::Thrust
         } else {

--- a/nyx-core/src/dynamics/guidance/mod.rs
+++ b/nyx-core/src/dynamics/guidance/mod.rs
@@ -40,7 +40,6 @@ pub use kluever::Kluever;
 use snafu::Snafu;
 
 use std::fmt;
-use std::sync::Arc;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -118,7 +117,7 @@ pub trait GuidanceLaw: fmt::Display + Send + Sync {
     fn throttle(&self, osc_state: &Spacecraft) -> Result<f64, GuidanceError>;
 
     /// Updates the state of the BaseSpacecraft for the next maneuver, e.g. prepares the controller for the next maneuver
-    fn next(&self, next_state: &mut Spacecraft, almanac: Arc<Almanac>);
+    fn next(&self, next_state: &mut Spacecraft, almanac: &Almanac);
 
     /// Returns whether this thrust control has been achieved, if it has an objective
     fn achieved(&self, _osc_state: &Spacecraft) -> Result<bool, GuidanceError> {

--- a/nyx-core/src/dynamics/guidance/replay.rs
+++ b/nyx-core/src/dynamics/guidance/replay.rs
@@ -110,7 +110,7 @@ impl GuidanceLaw for ThrustDirectionReplay {
         )
     }
 
-    fn next(&self, next_state: &mut Spacecraft, _almanac: Arc<Almanac>) {
+    fn next(&self, next_state: &mut Spacecraft, _almanac: &Almanac) {
         let thrust_direction = self
             .command_at_or_before(next_state)
             .and_then(|sample| sample.thrust_direction());

--- a/nyx-core/src/dynamics/guidance/ruggiero.rs
+++ b/nyx-core/src/dynamics/guidance/ruggiero.rs
@@ -422,12 +422,12 @@ impl GuidanceLaw for Ruggiero {
     }
 
     /// Update the state for the next iteration
-    fn next(&self, sc: &mut Spacecraft, almanac: Arc<Almanac>) {
+    fn next(&self, sc: &mut Spacecraft, almanac: &Almanac) {
         if sc.mode() != GuidanceMode::Inhibit {
             if !self.achieved(sc).unwrap() {
                 // Check eclipse state if applicable.
                 if let Some(max_eclipse) = self.max_eclipse_prct {
-                    let locator = ShadowModel::cislunar(almanac.clone());
+                    let locator = ShadowModel::cislunar(almanac);
                     if locator
                         .compute(sc.orbit, almanac)
                         .expect("cannot compute eclipse")

--- a/nyx-core/src/dynamics/mod.rs
+++ b/nyx-core/src/dynamics/mod.rs
@@ -27,7 +27,6 @@ use hyperdual::Owned;
 use snafu::Snafu;
 
 use std::fmt;
-use std::sync::Arc;
 
 pub use crate::errors::NyxError;
 
@@ -97,7 +96,7 @@ where
         delta_t: f64,
         state_vec: &OVector<f64, <Self::StateType as State>::VecLength>,
         state_ctx: &Self::StateType,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<OVector<f64, <Self::StateType as State>::VecLength>, DynamicsError>
     where
         DefaultAllocator: Allocator<<Self::StateType as State>::VecLength>;
@@ -109,7 +108,7 @@ where
         &self,
         _delta_t: f64,
         _osculating_state: &Self::StateType,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<
         (
             OVector<f64, <Self::StateType as State>::Size>,
@@ -132,7 +131,7 @@ where
     fn finally(
         &self,
         next_state: Self::StateType,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<Self::StateType, DynamicsError> {
         Ok(next_state)
     }
@@ -146,7 +145,7 @@ pub trait ForceModel: Send + Sync + fmt::Display {
     fn estimation_index(&self) -> Option<usize>;
 
     /// Defines the equations of motion for this force model from the provided osculating state.
-    fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError>;
+    fn eom(&self, ctx: &Spacecraft, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError>;
 
     /// Force models must implement their partials, although those will only be called if the propagation requires the
     /// computation of the STM. The `osc_ctx` is the osculating context, i.e. it changes for each sub-step of the integrator.
@@ -154,7 +153,7 @@ pub trait ForceModel: Send + Sync + fmt::Display {
     fn gradient(
         &self,
         osc_ctx: &Spacecraft,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError>;
 }
 
@@ -163,14 +162,14 @@ pub trait ForceModel: Send + Sync + fmt::Display {
 /// Examples include spherical harmonics, i.e. accelerations which do not need to save the current state, only act on it.
 pub trait AccelModel: Send + Sync + fmt::Display {
     /// Defines the equations of motion for this force model from the provided osculating state in the integration frame.
-    fn eom(&self, osc: &Orbit, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError>;
+    fn eom(&self, osc: &Orbit, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError>;
 
     /// Acceleration models must implement their partials, although those will only be called if the propagation requires the
     /// computation of the STM.
     fn gradient(
         &self,
         osc_ctx: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError>;
 }
 

--- a/nyx-core/src/dynamics/orbital.rs
+++ b/nyx-core/src/dynamics/orbital.rs
@@ -80,7 +80,7 @@ impl OrbitalDynamics {
     pub(crate) fn eom(
         &self,
         osc: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<OVector<f64, Const<42>>, DynamicsError> {
         // Still return something of size 42, but the STM will be zeros.
         let body_acceleration = (-osc
@@ -100,7 +100,7 @@ impl OrbitalDynamics {
 
         // Apply the acceleration models
         for model in &self.accel_models {
-            let model_acc = model.eom(osc, almanac.clone())?;
+            let model_acc = model.eom(osc, almanac)?;
             for i in 0..3 {
                 d_x[i + 3] += model_acc[i];
             }
@@ -117,7 +117,7 @@ impl OrbitalDynamics {
         &self,
         _delta_t_s: f64,
         osc: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector6<f64>, Matrix6<f64>), DynamicsError> {
         // Extract data from hyperspace
         // Build full state vector with partials in the right position (hence building with all six components)
@@ -157,7 +157,7 @@ impl OrbitalDynamics {
 
         // Apply the acceleration models
         for model in &self.accel_models {
-            let (model_acc, model_grad) = model.gradient(osc, almanac.clone())?;
+            let (model_acc, model_grad) = model.gradient(osc, almanac)?;
             for i in 0..3 {
                 dx[i + 3] += model_acc[i];
                 for j in 1..4 {
@@ -211,7 +211,7 @@ impl fmt::Display for PointMasses {
 }
 
 impl AccelModel for PointMasses {
-    fn eom(&self, osc: &Orbit, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
+    fn eom(&self, osc: &Orbit, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
         let mut d_x = Vector3::zeros();
         // Get all of the position vectors between the center body and the third bodies
         for third_body in self.celestial_objects.iter().copied() {
@@ -249,7 +249,7 @@ impl AccelModel for PointMasses {
     fn gradient(
         &self,
         osc: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError> {
         // Build the hyperdual space of the radius vector
         let radius: Vector3<OHyperdual<f64, Const<7>>> = hyperspace_from_vector(&osc.radius_km);

--- a/nyx-core/src/dynamics/solarpressure.rs
+++ b/nyx-core/src/dynamics/solarpressure.rs
@@ -132,7 +132,7 @@ impl ForceModel for SolarPressure {
         if self.estimate { Some(6) } else { None }
     }
 
-    fn eom(&self, ctx: &Spacecraft, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
+    fn eom(&self, ctx: &Spacecraft, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
         let osc = ctx.orbit;
         // Compute the position of the Sun as seen from the spacecraft
         let r_sun = almanac
@@ -167,7 +167,7 @@ impl ForceModel for SolarPressure {
     fn gradient(
         &self,
         ctx: &Spacecraft,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix4x3<f64>), DynamicsError> {
         let osc = ctx.orbit;
 
@@ -185,7 +185,7 @@ impl ForceModel for SolarPressure {
         // ANISE returns the occultation percentage (or factor), which is the opposite as the illumination factor.
         let occult = self
             .shadow_model
-            .compute(osc, almanac.clone())
+            .compute(osc, almanac)
             .context(DynamicsAlmanacSnafu {
                 action: "solar radiation pressure computation",
             })?

--- a/nyx-core/src/dynamics/solid_tides.rs
+++ b/nyx-core/src/dynamics/solid_tides.rs
@@ -226,13 +226,13 @@ impl SolidTides {
     fn accumulate_deltas(
         &self,
         epoch: Epoch,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<([[f64; 4]; 4], [[f64; 4]; 4]), DynamicsError> {
         let mut delta_c = [[0.0f64; 4]; 4];
         let mut delta_s = [[0.0f64; 4]; 4];
 
         for pert in &self.perturbers {
-            pert.compute_pert(epoch, self, &almanac, &mut delta_c, &mut delta_s)?;
+            pert.compute_pert(epoch, self, almanac, &mut delta_c, &mut delta_s)?;
         }
 
         Ok((delta_c, delta_s))
@@ -241,8 +241,8 @@ impl SolidTides {
 
 #[allow(clippy::needless_range_loop)]
 impl AccelModel for SolidTides {
-    fn eom(&self, osc: &Orbit, almanac: Arc<Almanac>) -> Result<Vector3<f64>, DynamicsError> {
-        let (delta_c, delta_s) = self.accumulate_deltas(osc.epoch, almanac.clone())?;
+    fn eom(&self, osc: &Orbit, almanac: &Almanac) -> Result<Vector3<f64>, DynamicsError> {
+        let (delta_c, delta_s) = self.accumulate_deltas(osc.epoch, almanac)?;
 
         // Convert the osculating orbit to the correct frame (needed for multiple harmonic fields)
         let state = almanac
@@ -385,9 +385,9 @@ impl AccelModel for SolidTides {
     fn gradient(
         &self,
         osc: &Orbit,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(Vector3<f64>, Matrix3<f64>), DynamicsError> {
-        let (delta_c, delta_s) = self.accumulate_deltas(osc.epoch, almanac.clone())?;
+        let (delta_c, delta_s) = self.accumulate_deltas(osc.epoch, almanac)?;
 
         // Convert the osculating orbit to the correct frame (needed for multiple harmonic fields)
         let state = almanac
@@ -587,14 +587,14 @@ mod tests {
 
         let tides = SolidTides::earth_moon_system(IAU_EARTH_FRAME, IAU_MOON_FRAME, almanac.clone())
             .expect("could not init solid tides");
-        let acc = tides.eom(&sc_orbit, almanac.clone()).unwrap();
+        let acc = tides.eom(&sc_orbit, &almanac).unwrap();
 
         println!("Solid tides acceleration: {:?}", acc);
         // Typical solid tide acceleration for LEO is around 1e-9 to 1e-7 km/s^2
         assert!(acc.norm() > 0.0);
         assert!(acc.norm() < 1e-6);
 
-        let (acc_grad, grad) = tides.gradient(&sc_orbit, almanac).unwrap();
+        let (acc_grad, grad) = tides.gradient(&sc_orbit, &almanac).unwrap();
         assert!((acc - acc_grad).norm() < 1e-12);
         assert!(grad.norm() > 0.0);
     }

--- a/nyx-core/src/dynamics/spacecraft.rs
+++ b/nyx-core/src/dynamics/spacecraft.rs
@@ -320,9 +320,7 @@ impl Dynamics for SpacecraftDynamics {
         let mut d_x = OVector::<f64, Const<9>>::zeros();
         let mut grad = OMatrix::<f64, Const<9>, Const<9>>::zeros();
 
-        let (orb_state, orb_grad) =
-            self.orbital_dyn
-                .dual_eom(delta_t_s, &ctx.orbit, almanac)?;
+        let (orb_state, orb_grad) = self.orbital_dyn.dual_eom(delta_t_s, &ctx.orbit, almanac)?;
 
         // Copy the d orbit dt data
         for (i, val) in orb_state.iter().enumerate() {

--- a/nyx-core/src/dynamics/spacecraft.rs
+++ b/nyx-core/src/dynamics/spacecraft.rs
@@ -158,7 +158,7 @@ impl Dynamics for SpacecraftDynamics {
     fn finally(
         &self,
         next_state: Self::StateType,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<Self::StateType, DynamicsError> {
         if next_state.mass.prop_mass_kg < 0.0 {
             error!("negative prop mass at {}", next_state.epoch());
@@ -179,7 +179,7 @@ impl Dynamics for SpacecraftDynamics {
 
             state.mut_thrust_direction(thrust_direction);
             // Update the control mode
-            guid_law.next(&mut state, almanac.clone());
+            guid_law.next(&mut state, almanac);
             Ok(state)
         } else {
             let mut state = next_state;
@@ -193,7 +193,7 @@ impl Dynamics for SpacecraftDynamics {
         delta_t_s: f64,
         state: &OVector<f64, Const<90>>,
         ctx: &Self::StateType,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<OVector<f64, Const<90>>, DynamicsError> {
         // Rebuild the osculating state for the EOM context.
         let osc_sc = ctx.set_with_delta_seconds(delta_t_s, state);
@@ -226,7 +226,7 @@ impl Dynamics for SpacecraftDynamics {
                 // Compute the orbital dynamics
                 for (i, val) in self
                     .orbital_dyn
-                    .eom(&osc_sc.orbit, almanac.clone())?
+                    .eom(&osc_sc.orbit, almanac)?
                     .iter()
                     .copied()
                     .enumerate()
@@ -236,7 +236,7 @@ impl Dynamics for SpacecraftDynamics {
 
                 // Apply the force models for non STM propagation
                 for model in &self.force_models {
-                    let model_frc = model.eom(&osc_sc, almanac.clone())? / osc_sc.mass_kg();
+                    let model_frc = model.eom(&osc_sc, almanac)? / osc_sc.mass_kg();
                     for i in 0..3 {
                         d_x[i + 3] += model_frc[i];
                     }
@@ -313,7 +313,7 @@ impl Dynamics for SpacecraftDynamics {
         &self,
         delta_t_s: f64,
         ctx: &Self::StateType,
-        almanac: Arc<Almanac>,
+        almanac: &Almanac,
     ) -> Result<(OVector<f64, Const<9>>, OMatrix<f64, Const<9>, Const<9>>), DynamicsError> {
         // Rebuild the appropriately sized state and STM.
         // This is the orbital state followed by Cr and Cd
@@ -322,7 +322,7 @@ impl Dynamics for SpacecraftDynamics {
 
         let (orb_state, orb_grad) =
             self.orbital_dyn
-                .dual_eom(delta_t_s, &ctx.orbit, almanac.clone())?;
+                .dual_eom(delta_t_s, &ctx.orbit, almanac)?;
 
         // Copy the d orbit dt data
         for (i, val) in orb_state.iter().enumerate() {
@@ -344,7 +344,7 @@ impl Dynamics for SpacecraftDynamics {
         // Call the EOMs
         let total_mass = ctx.mass_kg();
         for model in &self.force_models {
-            let (model_frc, model_grad) = model.gradient(ctx, almanac.clone())?;
+            let (model_frc, model_grad) = model.gradient(ctx, almanac)?;
             for i in 0..3 {
                 // Add the velocity changes
                 d_x[i + 3] += model_frc[i] / total_mass;

--- a/nyx-core/src/od/groundpnt/ground_dynamics.rs
+++ b/nyx-core/src/od/groundpnt/ground_dynamics.rs
@@ -21,7 +21,6 @@ use crate::od::groundpnt::GroundAsset;
 use anise::prelude::Almanac;
 use nalgebra::allocator::Allocator;
 use nalgebra::{Const, DefaultAllocator, Matrix6, OMatrix, OVector, Vector6};
-use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct GroundDynamics {}
@@ -35,7 +34,7 @@ impl Dynamics for GroundDynamics {
         _delta_t: f64,
         _state_vec: &OVector<f64, <Self::StateType as crate::State>::VecLength>,
         state_ctx: &Self::StateType,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<OVector<f64, <Self::StateType as crate::State>::VecLength>, DynamicsError>
     where
         DefaultAllocator: Allocator<<Self::StateType as crate::State>::VecLength>,
@@ -60,7 +59,7 @@ impl Dynamics for GroundDynamics {
         &self,
         _delta_t: f64,
         osc: &Self::StateType,
-        _almanac: Arc<Almanac>,
+        _almanac: &Almanac,
     ) -> Result<
         (
             OVector<f64, <Self::StateType as crate::State>::Size>,

--- a/nyx-core/src/propagators/instance.rs
+++ b/nyx-core/src/propagators/instance.rs
@@ -106,7 +106,7 @@ where
         self.state = self
             .prop
             .dynamics
-            .finally(self.state, self.almanac.clone())
+            .finally(self.state, &self.almanac)
             .context(DynamicsSnafu)?;
 
         let backprop = duration.is_negative();
@@ -346,7 +346,7 @@ where
         self.state = self
             .prop
             .dynamics
-            .finally(self.state, self.almanac.clone())
+            .finally(self.state, &self.almanac)
             .context(DynamicsSnafu)?;
         Ok(())
     }
@@ -369,7 +369,7 @@ where
             let ki = self
                 .prop
                 .dynamics
-                .eom(0.0, state_vec, state_ctx, self.almanac.clone())
+                .eom(0.0, state_vec, state_ctx, &self.almanac)
                 .context(DynamicsSnafu)?;
             self.k[0] = ki;
             let mut a_idx: usize = 0;
@@ -393,7 +393,7 @@ where
                         ci * step_size_s,
                         &(state_vec + step_size_s * wi),
                         state_ctx,
-                        self.almanac.clone(),
+                        &self.almanac,
                     )
                     .context(DynamicsSnafu)?;
                 self.k[i + 1] = ki;

--- a/nyx-core/tests/cosmic/eclipse.rs
+++ b/nyx-core/tests/cosmic/eclipse.rs
@@ -56,7 +56,7 @@ fn leo_sun_earth_eclipses(almanac: Arc<Almanac>) {
     let mut prev_eclipse_state: Option<Occultation> = None;
     let mut cnt_changes = 0;
     while let Ok(rx_state) = truth_rx.recv() {
-        let new_eclipse_state = e_loc.compute(rx_state.orbit, almanac.clone()).unwrap();
+        let new_eclipse_state = e_loc.compute(rx_state.orbit, &almanac).unwrap();
         if let Some(prev_state) = prev_eclipse_state {
             if new_eclipse_state.percentage != prev_state.percentage {
                 println!("{:.6} now in {}", rx_state.orbit.epoch, new_eclipse_state);
@@ -108,7 +108,7 @@ fn geo_sun_earth_eclipses(almanac: Arc<Almanac>) {
     let mut prev_eclipse_state: Option<Occultation> = None;
     let mut cnt_changes = 0;
     while let Ok(rx_state) = truth_rx.recv() {
-        let new_eclipse_state = e_loc.compute(rx_state.orbit, almanac.clone()).unwrap();
+        let new_eclipse_state = e_loc.compute(rx_state.orbit, &almanac).unwrap();
         if let Some(prev_state) = prev_eclipse_state {
             if new_eclipse_state.percentage != prev_state.percentage {
                 println!("{:.6} now in {}", rx_state.orbit.epoch, new_eclipse_state);

--- a/nyx-core/tests/mission_design/orbitaldyn.rs
+++ b/nyx-core/tests/mission_design/orbitaldyn.rs
@@ -697,13 +697,13 @@ fn two_body_dual(almanac: Arc<Almanac>) {
 
     let init_sc = Spacecraft::from(init).with_stm();
     let fx_real = dynamics
-        .eom(0.0, &init_sc.to_vector(), &init_sc, almanac.clone())
+        .eom(0.0, &init_sc.to_vector(), &init_sc, &almanac)
         .unwrap();
 
     let fx_orbit_real = fx_real.fixed_rows::<6>(0).to_owned();
 
     let (fx, grad) = dynamics
-        .dual_eom(0.0, &Spacecraft::from(init).with_stm(), almanac.clone())
+        .dual_eom(0.0, &Spacecraft::from(init).with_stm(), &almanac)
         .unwrap();
 
     let fx = fx.fixed_rows::<6>(0).to_owned();

--- a/nyx-core/tests/propagation/events.rs
+++ b/nyx-core/tests/propagation/events.rs
@@ -99,7 +99,7 @@ fn event_tracker_true_anomaly(almanac: Arc<Almanac>) {
     let mut min_dt = dt;
     let mut max_dt = dt;
     for state in traj.every(10 * Unit::Second) {
-        let new_e_state = e_loc.compute(state.orbit, almanac.clone()).unwrap();
+        let new_e_state = e_loc.compute(state.orbit, &almanac).unwrap();
         if let Some(prev_state) = e_state {
             if prev_state.percentage != new_e_state.percentage {
                 println!("{state:x}\t{new_e_state}");

--- a/nyx-core/tests/propagation/trajectory.rs
+++ b/nyx-core/tests/propagation/trajectory.rs
@@ -103,7 +103,7 @@ fn traj_ephem_forward(almanac: Arc<Almanac>) {
     let eval_state = ephem.at(start_dt).unwrap();
 
     let mut max_pos_err = (eval_state.orbit.radius_km - start_state.radius_km).norm();
-    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.velocity_km_s).norm();
+    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
 
     while let Ok(prop_state) = rx.recv() {
         let eval_state = ephem.at(prop_state.epoch()).unwrap();
@@ -306,7 +306,7 @@ fn traj_spacecraft(almanac: Arc<Almanac>) {
 
     for mut sc_state in traj.every(1 * Unit::Day) {
         // We need to evaluate the mode of this state because the trajectory does not store discrete information
-        ruggiero_ctrl.next(&mut sc_state, almanac.clone());
+        ruggiero_ctrl.next(&mut sc_state, &almanac);
         if sc_state.mode() != prev_mode {
             println!(
                 "Mode changed from {:?} to {:?} @ {}",
@@ -321,7 +321,7 @@ fn traj_spacecraft(almanac: Arc<Almanac>) {
     for epoch in TimeSeries::inclusive(start_dt, start_dt + prop_time, 1 * Unit::Day) {
         // Note: the `evaluate` function will return a Result which prevents a panic if you request something out of the ephemeris
         let mut sc_state = traj.at(epoch).unwrap();
-        ruggiero_ctrl.next(&mut sc_state, almanac.clone());
+        ruggiero_ctrl.next(&mut sc_state, &almanac);
         if sc_state.mode() != prev_mode {
             println!(
                 "Mode changed from {:?} to {:?} @ {}",
@@ -358,6 +358,7 @@ fn traj_spacecraft(almanac: Arc<Almanac>) {
     let eval_state = traj.at(start_dt).unwrap();
 
     let mut max_pos_err = (eval_state.orbit.radius_km - start_state.orbit.radius_km).norm();
+    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
     let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
     let mut max_prop_err = eval_state.mass.prop_mass_kg - start_state.mass.prop_mass_kg;
     let mut max_err = (eval_state.to_vector() - start_state.to_vector()).norm();

--- a/nyx-core/tests/propagation/trajectory.rs
+++ b/nyx-core/tests/propagation/trajectory.rs
@@ -103,7 +103,7 @@ fn traj_ephem_forward(almanac: Arc<Almanac>) {
     let eval_state = ephem.at(start_dt).unwrap();
 
     let mut max_pos_err = (eval_state.orbit.radius_km - start_state.radius_km).norm();
-    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
+    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.velocity_km_s).norm();
 
     while let Ok(prop_state) = rx.recv() {
         let eval_state = ephem.at(prop_state.epoch()).unwrap();
@@ -358,7 +358,6 @@ fn traj_spacecraft(almanac: Arc<Almanac>) {
     let eval_state = traj.at(start_dt).unwrap();
 
     let mut max_pos_err = (eval_state.orbit.radius_km - start_state.orbit.radius_km).norm();
-    let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
     let mut max_vel_err = (eval_state.orbit.velocity_km_s - start_state.orbit.velocity_km_s).norm();
     let mut max_prop_err = eval_state.mass.prop_mass_kg - start_state.mass.prop_mass_kg;
     let mut max_err = (eval_state.to_vector() - start_state.to_vector()).norm();


### PR DESCRIPTION
This PR refactors the core astrodynamics traits (`Dynamics`, `ForceModel`, `AccelModel`) and the `GuidanceLaw` trait to accept a reference to the `Almanac` (`&Almanac`) instead of a shared pointer (`Arc<Almanac>`). 

The motivation for this change is architectural and performance-related:
1. **Performance**: Evaluating the equations of motion (EOM) is the innermost loop of propagation. Using a reference avoids the atomic reference count increment/decrement associated with cloning an `Arc` multiple times per integration step.
2. **Semantics**: The EOM and guidance functions only need read-only access to the almanac for the duration of the call. A borrow more accurately reflects this requirement than shared ownership.
3. **API Flexibility**: Users can now pass stack-allocated or static almanacs without needing to wrap them in an `Arc`.

All implementations within `nyx-core` have been updated, and associated tests and examples have been adjusted to comply with the new method signatures.

Fixes #557

---
*PR created automatically by Jules for task [4634320921732235598](https://jules.google.com/task/4634320921732235598) started by @ChristopherRabotin*