### PR TITLE
Add configuration for solid tides to sequence AccelModels

### DIFF
--- a/nyx-core/examples/03_geo_analysis/raise_optim.rs
+++ b/nyx-core/examples/03_geo_analysis/raise_optim.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Set up the genetic algorithm optimization
     let codec = FloatCodec::vector(3, 0.1_f32..1.0_f32); // 3 weights for SMA, Ecc, Inc
-    let problem = EngineProblem {
+    let problem = radiate::problem::EngineProblem {
         objective: radiate::Objective::Multi(vec![Optimize::Minimize, Optimize::Minimize]), // NSGA2 Multi Objective
         codec: Arc::new(codec),
         fitness_fn: Some(Arc::new(move |weights: Vec<f32>| {

--- a/nyx-core/src/dynamics/sequence/config.rs
+++ b/nyx-core/src/dynamics/sequence/config.rs
@@ -113,6 +113,24 @@ impl Dynamics {
             let gravity_field = GravityField::new(grav_data);
             orbital_dyn.accel_models.push(gravity_field);
         }
+        let mut perturbers = Vec::new();
+        for tb in self.accel_models.solid_tides.iter().flatten() {
+            let frame = almanac.frame_info(tb.frame).map_err(|e| e.to_string())?;
+            perturbers.push(crate::dynamics::solid_tides::TidalPerturber {
+                frame,
+                compute_degree_3: tb.compute_degree_3,
+            });
+        }
+        if !perturbers.is_empty() {
+            let central_frame = almanac.frame_info(self.accel_models.gravity_field.as_ref().map(|g| g.frame).unwrap_or(anise::constants::frames::IAU_EARTH_FRAME.into())).map_err(|e| e.to_string())?;
+            let solid_tides = crate::dynamics::solid_tides::SolidTides {
+                frame: central_frame,
+                k2: 0.3019,
+                k3: 0.093,
+                perturbers,
+            };
+            orbital_dyn.accel_models.push(std::sync::Arc::new(solid_tides));
+        }
         // Build the spacecraft dynamics
         let mut sc_dyn = SpacecraftDynamics::new(orbital_dyn);
 
@@ -154,6 +172,15 @@ impl PropagatorConfig {
 pub struct AccelModels {
     pub point_masses: Option<PointMasses>,
     pub gravity_field: Option<GravityFieldConfig>,
+    pub solid_tides: [Option<TidalBody>; 2],
+}
+
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, StaticType)]
+#[cfg_attr(feature = "python", pyclass(from_py_object, get_all, set_all))]
+pub struct TidalBody {
+    pub frame: FrameUid,
+    pub compute_degree_3: bool,
 }
 
 /// Force models alter the spacecraft dynamics (they need a mass).
@@ -205,6 +232,11 @@ impl StaticType for AccelModels {
         fields.insert(
             "gravity_field".to_string(),
             SimpleType::Optional(Box::new(GravityFieldDhall::static_type())),
+        );
+
+        fields.insert(
+            "solid_tides".to_string(),
+            SimpleType::List(Box::new(SimpleType::Optional(Box::new(TidalBody::static_type())))),
         );
 
         SimpleType::Record(fields)

--- a/nyx-core/src/dynamics/sequence/mod.rs
+++ b/nyx-core/src/dynamics/sequence/mod.rs
@@ -37,7 +37,7 @@ use crate::md::Trajectory;
 use crate::propagators::Propagator;
 use crate::{NyxError, Spacecraft, State};
 
-mod config;
+pub mod config;
 mod discrete_event;
 
 pub use config::*;

--- a/nyx-core/src/dynamics/sequence/python.rs
+++ b/nyx-core/src/dynamics/sequence/python.rs
@@ -1,6 +1,7 @@
 use super::{AccelModels, Dynamics, ForceModels, PropagatorConfig, SpacecraftSequence, Thruster};
 #[cfg(feature = "python")]
 use crate::dynamics::{Drag, SolarPressure};
+use crate::dynamics::sequence::config::TidalBody;
 use crate::propagators::{IntegratorMethod, IntegratorOptions};
 use crate::{dynamics::PointMasses, io::gravity::GravityFieldConfig};
 use pyo3::exceptions::PyException;
@@ -81,16 +82,30 @@ impl SpacecraftSequence {
 #[cfg(feature = "python")]
 #[cfg_attr(feature = "python", pymethods)]
 impl AccelModels {
-    #[pyo3(signature=(point_masses=None, gravity_field=None))]
+    #[pyo3(signature=(point_masses=None, gravity_field=None, solid_tides=None))]
     #[new]
     fn py_new(
         point_masses: Option<PointMasses>,
         gravity_field: Option<GravityFieldConfig>,
-    ) -> Self {
-        Self {
+        solid_tides: Option<Vec<TidalBody>>,
+    ) -> PyResult<Self> {
+        let mut st = [None, None];
+        if let Some(tides) = solid_tides {
+            if tides.len() > 2 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "A maximum of 2 tidal bodies is supported.",
+                ));
+            }
+            for (i, body) in tides.into_iter().enumerate() {
+                st[i] = Some(body);
+            }
+        }
+        Ok(Self {
             point_masses,
             gravity_field,
-        }
+            solid_tides: st,
+        })
+
     }
 
     fn __str__(&self) -> String {
@@ -162,5 +177,14 @@ impl PropagatorConfig {
 
     fn __repr__(&self) -> String {
         format!("{self:?} @ {self:p}")
+    }
+}
+
+#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
+impl TidalBody {
+    #[new]
+    fn py_new(frame: anise::frames::FrameUid, compute_degree_3: bool) -> Self {
+        Self { frame, compute_degree_3 }
     }
 }

--- a/nyx-core/tests/mission_design/sequence.rs
+++ b/nyx-core/tests/mission_design/sequence.rs
@@ -57,6 +57,7 @@ fn spacecraft_sequence(almanac: Arc<Almanac>) {
                         order: 21,
                         frame: IAU_EARTH_FRAME.into(),
                     }),
+                    solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,
@@ -87,6 +88,7 @@ fn spacecraft_sequence(almanac: Arc<Almanac>) {
                         order: 8,
                         frame: IAU_EARTH_FRAME.into(),
                     }),
+                    solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: Some(
@@ -318,6 +320,7 @@ fn spacecraft_low_thrust_orbit_raise(
                         order: 8,
                         frame: IAU_EARTH_FRAME.into(),
                     }),
+                    solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,

--- a/nyx-core/tests/mission_design/targeter/finite_burns.rs
+++ b/nyx-core/tests/mission_design/targeter/finite_burns.rs
@@ -241,7 +241,7 @@ fn val_tgt_finite_burn(almanac: Arc<Almanac>) {
             dynamics: Dynamics {
                 accel_models: AccelModels {
                     point_masses: Some(PointMasses::new(bodies)),
-                    gravity_field: None,
+                    gravity_field: None, solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,

--- a/nyx-core/tests/propulsion/schedule.rs
+++ b/nyx-core/tests/propulsion/schedule.rs
@@ -70,7 +70,7 @@ fn val_transfer_schedule_no_depl(almanac: Arc<Almanac>) {
             dynamics: Dynamics {
                 accel_models: AccelModels {
                     point_masses: Some(PointMasses::new(vec![MOON, SUN, JUPITER_BARYCENTER])),
-                    gravity_field: None,
+                    gravity_field: None, solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,
@@ -193,7 +193,7 @@ fn val_transfer_schedule_depl(almanac: Arc<Almanac>) {
             dynamics: Dynamics {
                 accel_models: AccelModels {
                     point_masses: Some(PointMasses::new(bodies)),
-                    gravity_field: None,
+                    gravity_field: None, solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,
@@ -478,7 +478,7 @@ fn finite_burns_respects_gaps_between_maneuvers(almanac: Arc<Almanac>) {
             dynamics: Dynamics {
                 accel_models: AccelModels {
                     point_masses: Some(PointMasses::new(vec![MOON, SUN, JUPITER_BARYCENTER])),
-                    gravity_field: None,
+                    gravity_field: None, solid_tides: [None, None],
                 },
                 force_models: ForceModels {
                     solar_pressure: None,

--- a/nyx-py/src/lib.rs
+++ b/nyx-py/src/lib.rs
@@ -48,6 +48,7 @@ use nyx_space::dynamics::guidance::Thruster;
 use nyx_space::dynamics::sequence::{
     AccelModels, Dynamics, ForceModels, PropagatorConfig, SpacecraftSequence,
 };
+use nyx_space::dynamics::sequence::config::TidalBody;
 use nyx_space::dynamics::{AtmDensity, Drag, PointMasses, SolarPressure};
 use nyx_space::io::gravity::GravityFieldConfig;
 use nyx_space::mc::{MvnSpacecraft, StateDispersion};
@@ -138,6 +139,7 @@ fn mission_design(_py: Python, sm: &Bound<PyModule>) -> PyResult<()> {
     sm.add_class::<IntegratorMethod>()?;
     sm.add_class::<IntegratorOptions>()?;
     sm.add_class::<AccelModels>()?;
+    sm.add_class::<TidalBody>()?;
     sm.add_class::<ForceModels>()?;
     sm.add_class::<SpacecraftSequence>()?;
     sm.add_class::<GravityFieldConfig>()?;

--- a/nyx-py/tests/test_mission_design.py
+++ b/nyx-py/tests/test_mission_design.py
@@ -8,6 +8,7 @@ from nyx_space.anise.analysis import Condition, Event, OrbitalElement, ScalarExp
 from nyx_space.anise.astro import Orbit
 from nyx_space.anise.constants import CelestialObjects, Frames
 from nyx_space.mission_design import (
+    TidalBody,
     AccelModels,
     AtmDensity,
     Drag,
@@ -340,3 +341,63 @@ if __name__ == "__main__":
     test_howto_propagate_with_perturbations()
     test_howto_execute_simple_monte_carlo()
     test_howto_configure_spherical_harmonics()
+
+def test_solid_tides_cislunar():
+    from nyx_space.mission_design import TidalBody
+    almanac = MetaAlmanac("../data/02_config/ci_almanac.dhall").process()
+
+    # Define tidal bodies for the Earth-Moon system
+    # We want to model the solid tides of the Earth, caused by the Moon and the Sun.
+    # We create TidalBodies for the Moon and the Sun.
+    tidal_body_moon = TidalBody(
+        frame=Frames.IAU_MOON_FRAME.to_frameuid(),
+        compute_degree_3=True
+    )
+    tidal_body_sun = TidalBody(
+        frame=Frames.SUN_J2000.to_frameuid(),
+        compute_degree_3=True
+    )
+
+    # Configure gravity field for the central body (Earth)
+    gravity_cfg = GravityFieldConfig(
+        degree=2,
+        order=0,
+        filepath="../data/01_planetary/EGM2008_to2190_TideFree.gz",
+        frame=Frames.IAU_EARTH_FRAME.to_frameuid()
+    )
+
+    accel_models = AccelModels(
+        gravity_field=gravity_cfg,
+        solid_tides=[tidal_body_moon, tidal_body_sun]
+    )
+
+    # Combine accelerations into a unified Dynamics model
+    dynamics = Dynamics(accel_models)
+
+    # Set up the propagator
+    propagator = Propagator(dynamics, almanac, IntegratorMethod.DormandPrince78)
+
+    epoch = Epoch.from_gregorian_utc(2023, 1, 1, 12, 0, 0, 0)
+    orbit = Orbit.from_keplerian(
+        sma_km=40000.0,
+        ecc=0.1,
+        inc_deg=10.0,
+        raan_deg=0.0,
+        aop_deg=0.0,
+        ta_deg=0.0,
+        epoch=epoch,
+        frame=almanac.frame_info(Frames.EARTH_J2000),
+    )
+
+    spacecraft = Spacecraft(orbit=orbit, mass=Mass(1500.0))
+
+    final_state = propagator.for_duration(spacecraft, Unit.Day * 1)
+    logging.info(
+        f"Final position magnitude after 1 day with solid tides: {final_state.state.orbit.rmag_km():.3f} km"
+    )
+
+    # TEST Verify the propagation ran successfully
+    assert final_state.state.orbit.rmag_km() > 0.0
+
+if __name__ == "__main__":
+    test_solid_tides_cislunar()


### PR DESCRIPTION
Adds the ability to configure solid tides directly in the `AccelModels` sequence struct and exposes this functionality to the Python interface. This allows users to model the crust deformation due to up to two tidal bodies (typically Moon and Sun) during sequence propagation. Includes tests and handles Python binding edge cases for arrays of options.

---
*PR created automatically by Jules for task [15089452962352936726](https://jules.google.com/task/15089452962352936726) started by @ChristopherRabotin*