### PR TITLE
Utils refactor

### DIFF
--- a/nyx-core/examples/04_lro_od/main.rs
+++ b/nyx-core/examples/04_lro_od/main.rs
@@ -13,21 +13,21 @@ use anise::{
 };
 use hifitime::{Epoch, TimeSeries, TimeUnits, Unit};
 use nyx::{
+    Orbit, Spacecraft, State,
     cosmic::{Aberration, Frame, Mass, MetaAlmanac, SRPData},
     dynamics::{
-        guidance::LocalFrame, GravityField, OrbitalDynamics, SolarPressure, SpacecraftDynamics,
+        GravityField, OrbitalDynamics, SolarPressure, SpacecraftDynamics, guidance::LocalFrame,
     },
     io::{ConfigRepr, ExportCfg},
     md::prelude::{GravityFieldData, Traj},
     od::{
+        GroundStation, SpacecraftKalmanOD,
         msr::MeasurementType,
         prelude::{KalmanVariant, TrackingArcSim, TrkConfig},
         process::{Estimate, NavSolution, ResidRejectCrit, SpacecraftUncertainty},
         snc::ProcessNoise3D,
-        GroundStation, SpacecraftKalmanOD,
     },
     propagators::Propagator,
-    Orbit, Spacecraft, State,
 };
 
 use std::{collections::BTreeMap, error::Error, path::PathBuf, str::FromStr, sync::Arc};

--- a/nyx-core/src/md/opti/raphson_hyperdual.rs
+++ b/nyx-core/src/md/opti/raphson_hyperdual.rs
@@ -135,7 +135,7 @@ impl<const V: usize, const O: usize> Targeter<'_, V, O> {
                 .context(PropSnafu)?;
 
             // Check linearization
-            if !are_eigenvalues_stable(xf.stm().unwrap().complex_eigenvalues()) {
+            if !are_eigenvalues_stable(&xf.stm().unwrap().complex_eigenvalues()) {
                 warn!(
                     "STM linearization assumption is wrong for a time step of {}",
                     achievement_epoch - correction_epoch

--- a/nyx-core/src/utils.rs
+++ b/nyx-core/src/utils.rs
@@ -807,5 +807,100 @@ fn spherical() {
         let v_prime = spherical_to_cartesian(range_ρ, θ, φ);
 
         assert!(rss_errors(v, &v_prime) < 1e-12, "{} != {}", v, &v_prime);
+    trait FailureTolerance {
+        fn within_tolerance(&self, other: Self) -> bool;
+    }
+
+    impl FailureTolerance for f64 {
+        fn within_tolerance(&self, other: Self) -> bool {
+            (self - other).abs() < f64::EPSILON
+        }
+    }
+    #[test]
+    fn test_angle_bounds() {
+        assert!(between_pm_180(181.0).within_tolerance(-179.0));
+        assert!(between_0_360(-179.0).within_tolerance(181.0));
+    }
+
+    #[test]
+    fn test_positive_angle() {
+        assert!(between_0_360(450.0).within_tolerance(90.0));
+        assert!(between_pm_x(270.0, 180.0).within_tolerance(-90.0));
+    }
+
+    #[test]
+    fn test_negative_angle() {
+        assert!(between_0_360(-90.0).within_tolerance(270.0));
+        assert!(between_pm_x(-270.0, 180.0).within_tolerance(90.0));
+    }
+
+    #[test]
+    fn test_angle_in_range() {
+        assert!(between_0_360(180.0).within_tolerance(180.0));
+        assert!(between_pm_x(90.0, 180.0).within_tolerance(90.0));
+    }
+
+    #[test]
+    fn test_zero_angle() {
+        assert!(between_0_360(0.0).within_tolerance(0.0));
+        assert!(between_pm_x(0.0, 180.0).within_tolerance(0.0));
+    }
+
+    #[test]
+    fn test_full_circle_angle() {
+        assert!(between_0_360(360.0).within_tolerance(0.0));
+        assert!(between_pm_x(360.0, 180.0).within_tolerance(0.0));
+    }
+
+    #[test]
+    fn test_rss_errors() {
+        use nalgebra::U3;
+        let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+        let cur_state = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+        assert!(rss_errors(&prop_err, &cur_state).within_tolerance(0.0));
+
+        let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
+        let cur_state = OVector::<f64, U3>::from_iterator([4.0, 5.0, 6.0]);
+        assert!(rss_errors(&prop_err, &cur_state).within_tolerance(5.196152422706632));
+    }
+
+    #[test]
+    fn test_normalize() {
+        let x = 5.0;
+        let min_x = 0.0;
+        let max_x = 10.0;
+        let result = normalize(x, min_x, max_x);
+        assert!(result.within_tolerance(0.0));
+    }
+
+    #[test]
+    fn test_denormalize() {
+        let xp = 0.0;
+        let min_x = 0.0;
+        let max_x = 10.0;
+        let result = denormalize(xp, min_x, max_x);
+        assert!(result.within_tolerance(5.0));
+    }
+
+    #[test]
+    fn test_tilde_matrix() {
+        let vec = Vector3::new(1.0, 2.0, 3.0);
+        let rslt = Matrix3::new(0.0, -3.0, 2.0, 3.0, 0.0, -1.0, -2.0, 1.0, 0.0);
+        assert_eq!(tilde_matrix(&vec), rslt);
+
+        let v = Vector3::new(1.0, 2.0, 3.0);
+        let m = tilde_matrix(&v);
+
+        assert!(m[(0, 0)].within_tolerance(0.0));
+        assert!(m[(0, 1)].within_tolerance(-v.z));
+        assert!(m[(0, 2)].within_tolerance(v.y));
+        assert!(m[(1, 0)].within_tolerance(v.z));
+        assert!(m[(1, 1)].within_tolerance(0.0));
+        assert!(m[(1, 2)].within_tolerance(-v.x));
+        assert!(m[(2, 0)].within_tolerance(-v.y));
+        assert!(m[(2, 1)].within_tolerance(v.x));
+        assert!(m[(2, 2)].within_tolerance(0.0));
+    }
+
     }
 }

--- a/nyx-core/src/utils.rs
+++ b/nyx-core/src/utils.rs
@@ -39,25 +39,6 @@ pub fn tilde_matrix(v: &Vector3<f64>) -> Matrix3<f64> {
     Matrix3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
 }
 
-#[test]
-fn test_tilde_matrix() {
-    let vec = Vector3::new(1.0, 2.0, 3.0);
-    let rslt = Matrix3::new(0.0, -3.0, 2.0, 3.0, 0.0, -1.0, -2.0, 1.0, 0.0);
-    assert_eq!(tilde_matrix(&vec), rslt);
-
-    let v = Vector3::new(1.0, 2.0, 3.0);
-    let m = tilde_matrix(&v);
-
-    assert_eq!(m[(0, 0)], 0.0);
-    assert_eq!(m[(0, 1)], -v.z);
-    assert_eq!(m[(0, 2)], v.y);
-    assert_eq!(m[(1, 0)], v.z);
-    assert_eq!(m[(1, 1)], 0.0);
-    assert_eq!(m[(1, 2)], -v.x);
-    assert_eq!(m[(2, 0)], -v.y);
-    assert_eq!(m[(2, 1)], v.x);
-    assert_eq!(m[(2, 2)], 0.0);
-}
 
 /// Checks if the provided 3x3 matrix is diagonal.
 ///
@@ -130,52 +111,13 @@ pub fn is_diagonal(m: &Matrix3<f64>) -> bool {
 /// # Source
 ///
 /// [Chemical Process Dynamics and Controls (Woolf)](https://eng.libretexts.org/Bookshelves/Industrial_and_Systems_Engineering/Book%3A_Chemical_Process_Dynamics_and_Controls_(Woolf)/10%3A_Dynamical_Systems_Analysis/10.04%3A_Using_eigenvalues_and_eigenvectors_to_find_stability_and_solve_ODEs#Summary_of_Eigenvalue_Graphs)
-pub fn are_eigenvalues_stable<N: DimName>(eigenvalues: OVector<Complex<f64>, N>) -> bool
+pub fn are_eigenvalues_stable<N: DimName>(eigenvalues: &OVector<Complex<f64>, N>) -> bool
 where
     DefaultAllocator: Allocator<N>,
 {
     eigenvalues.iter().all(|ev| ev.re <= 0.0)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use nalgebra::{Complex, OVector};
-
-    #[test]
-    fn test_stable_eigenvalues() {
-        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
-            Complex::new(-1.0, 0.0),
-            Complex::new(0.0, 0.0),
-        ]);
-        assert!(are_eigenvalues_stable(eigenvalues));
-    }
-
-    #[test]
-    fn test_unstable_eigenvalues() {
-        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
-            Complex::new(1.0, 0.0),
-            Complex::new(0.0, 0.0),
-        ]);
-        assert!(!are_eigenvalues_stable(eigenvalues));
-    }
-
-    #[test]
-    fn test_oscillatory_eigenvalues() {
-        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
-            Complex::new(0.0, 1.0),
-            Complex::new(0.0, -1.0),
-        ]);
-        assert!(are_eigenvalues_stable(eigenvalues));
-    }
-
-    #[test]
-    fn test_invariant_eigenvalues() {
-        let eigenvalues =
-            OVector::<Complex<f64>, nalgebra::U1>::from_column_slice(&[Complex::new(0.0, 0.0)]);
-        assert!(are_eigenvalues_stable(eigenvalues));
-    }
-}
 
 /// Returns the provided angle bounded between 0.0 and 360.0.
 ///
@@ -259,22 +201,6 @@ pub fn r1(angle_rad: f64) -> Matrix3<f64> {
     Matrix3::new(1.0, 0.0, 0.0, 0.0, c, s, 0.0, -s, c)
 }
 
-#[test]
-fn test_r1() {
-    let angle = 0.0;
-    let rotation_matrix = r1(angle);
-    assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
-
-    let angle = std::f64::consts::PI / 2.0;
-    let rotation_matrix = r1(angle);
-    let expected_matrix = Matrix3::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0);
-    assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
-
-    let v = Vector3::new(1.0, 0.0, 0.0);
-    let rotated_v = rotation_matrix * v;
-    assert!((rotated_v - v).norm() <= f64::EPSILON);
-}
-
 /// Returns a rotation matrix for a rotation about the Y axis.
 ///
 /// # Arguments
@@ -302,22 +228,6 @@ fn test_r1() {
 pub fn r2(angle_rad: f64) -> Matrix3<f64> {
     let (s, c) = angle_rad.sin_cos();
     Matrix3::new(c, 0.0, -s, 0.0, 1.0, 0.0, s, 0.0, c)
-}
-
-#[test]
-fn test_r2() {
-    let angle = 0.0;
-    let rotation_matrix = r2(angle);
-    assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
-
-    let angle = std::f64::consts::PI / 2.0;
-    let rotation_matrix = r2(angle);
-    let expected_matrix = Matrix3::new(0.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0);
-    assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
-
-    let v = Vector3::new(0.0, 1.0, 0.0);
-    let rotated_v = rotation_matrix * v;
-    assert!((rotated_v - v).norm() <= f64::EPSILON);
 }
 
 /// Returns a rotation matrix for a rotation about the Z axis.
@@ -349,22 +259,6 @@ pub fn r3(angle_rad: f64) -> Matrix3<f64> {
     Matrix3::new(c, s, 0.0, -s, c, 0.0, 0.0, 0.0, 1.0)
 }
 
-#[test]
-fn test_r3() {
-    let angle = 0.0;
-    let rotation_matrix = r3(angle);
-    assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
-
-    let angle = std::f64::consts::PI / 2.0;
-    let rotation_matrix = r3(angle);
-    let expected_matrix = Matrix3::new(0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
-    assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
-
-    let v = Vector3::new(0.0, 0.0, 1.0);
-    let rotated_v = rotation_matrix * v;
-    assert!((rotated_v - v).norm() <= f64::EPSILON);
-}
-
 /// Rotate a vector about a given axis
 ///
 /// # Arguments
@@ -383,15 +277,6 @@ pub fn rotv(v: &Vector3<f64>, axis: &Vector3<f64>, theta: f64) -> Vector3<f64> {
         + k_hat.scale(k_hat.dot(v) * (1.0 - theta.cos()))
 }
 
-#[test]
-fn test_rotv() {
-    use approx::assert_abs_diff_eq;
-    let v = Vector3::new(1.0, 0.0, 0.0);
-    let axis = Vector3::new(0.0, 0.0, 1.0);
-    let theta = std::f64::consts::PI / 2.0;
-    let result = rotv(&v, &axis, theta);
-    assert_abs_diff_eq!(result, Vector3::new(0.0, 1.0, 0.0), epsilon = 1e-7);
-}
 
 /// Returns the components of vector a orthogonal to b
 ///
@@ -418,30 +303,6 @@ pub fn perpv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
     }
 }
 
-#[test]
-fn test_perpv() {
-    assert_eq!(
-        perpv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(2.0, 0.0, 0.0)),
-        Vector3::new(0.0, 6.0, 6.0)
-    );
-    assert_eq!(
-        perpv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(-3.0, 0.0, 0.0)),
-        Vector3::new(0.0, 6.0, 6.0)
-    );
-    assert_eq!(
-        perpv(&Vector3::new(6.0, 6.0, 0.0), &Vector3::new(0.0, 7.0, 0.0)),
-        Vector3::new(6.0, 0.0, 0.0)
-    );
-    assert_eq!(
-        perpv(&Vector3::new(6.0, 0.0, 0.0), &Vector3::new(0.0, 0.0, 9.0)),
-        Vector3::new(6.0, 0.0, 0.0)
-    );
-    use approx::assert_abs_diff_eq;
-    let a = Vector3::new(1.0, 1.0, 0.0);
-    let b = Vector3::new(1.0, 0.0, 0.0);
-    let result = perpv(&a, &b);
-    assert_abs_diff_eq!(result, Vector3::new(0.0, 1.0, 0.0), epsilon = 1e-7);
-}
 
 /// Returns the projection of a onto b
 ///
@@ -462,31 +323,6 @@ pub fn projv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
     }
 }
 
-#[test]
-fn test_projv() {
-    assert_eq!(
-        projv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(2.0, 0.0, 0.0)),
-        Vector3::new(6.0, 0.0, 0.0)
-    );
-    assert_eq!(
-        projv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(-3.0, 0.0, 0.0)),
-        Vector3::new(6.0, 0.0, 0.0)
-    );
-    assert_eq!(
-        projv(&Vector3::new(6.0, 6.0, 0.0), &Vector3::new(0.0, 7.0, 0.0)),
-        Vector3::new(0.0, 6.0, 0.0)
-    );
-    assert_eq!(
-        projv(&Vector3::new(6.0, 0.0, 0.0), &Vector3::new(0.0, 0.0, 9.0)),
-        Vector3::new(0.0, 0.0, 0.0)
-    );
-
-    use approx::assert_abs_diff_eq;
-    let a = Vector3::new(1.0, 1.0, 0.0);
-    let b = Vector3::new(1.0, 0.0, 0.0);
-    let result = projv(&a, &b);
-    assert_abs_diff_eq!(result, Vector3::new(1.0, 0.0, 0.0), epsilon = 1e-7);
-}
 
 /// Computes the Root Sum Squared (RSS) state errors between two provided vectors.
 ///
@@ -508,18 +344,6 @@ where
         .map(|(&x, &y)| (x - y).powi(2))
         .sum::<f64>()
         .sqrt()
-}
-
-#[test]
-fn test_rss_errors() {
-    use nalgebra::U3;
-    let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
-    let cur_state = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
-    assert_eq!(rss_errors(&prop_err, &cur_state), 0.0);
-
-    let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
-    let cur_state = OVector::<f64, U3>::from_iterator([4.0, 5.0, 6.0]);
-    assert_eq!(rss_errors(&prop_err, &cur_state), 5.196152422706632);
 }
 
 /// Computes the Root Sum Squared (RSS) orbit errors in kilometers and kilometers per second.
@@ -570,15 +394,6 @@ pub fn normalize(x: f64, min_x: f64, max_x: f64) -> f64 {
     2.0 * (x - min_x) / (max_x - min_x) - 1.0
 }
 
-#[test]
-fn test_normalize() {
-    let x = 5.0;
-    let min_x = 0.0;
-    let max_x = 10.0;
-    let result = normalize(x, min_x, max_x);
-    assert_eq!(result, 0.0);
-}
-
 /// Denormalize a value between -1.0 and 1.0
 ///
 /// # Arguments
@@ -594,15 +409,6 @@ pub fn denormalize(xp: f64, min_x: f64, max_x: f64) -> f64 {
     (max_x - min_x) * (xp + 1.0) / 2.0 + min_x
 }
 
-#[test]
-fn test_denormalize() {
-    let xp = 0.0;
-    let min_x = 0.0;
-    let max_x = 10.0;
-    let result = denormalize(xp, min_x, max_x);
-    assert_eq!(result, 5.0);
-}
-
 /// Capitalize the first letter of a string
 ///
 /// # Arguments
@@ -615,7 +421,7 @@ fn test_denormalize() {
 ///
 /// # Source
 ///
-/// https://stackoverflow.com/questions/38406793/why-is-capitalizing-the-first-letter-of-a-string-so-convoluted-in-rust
+/// <https://stackoverflow.com/questions/38406793/why-is-capitalizing-the-first-letter-of-a-string-so-convoluted-in-rust>
 pub fn capitalize(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
@@ -624,12 +430,6 @@ pub fn capitalize(s: &str) -> String {
     }
 }
 
-#[test]
-fn test_capitalize() {
-    let s = "hello";
-    let result = capitalize(s);
-    assert_eq!(result, "Hello");
-}
 
 #[macro_export]
 macro_rules! pseudo_inverse {
@@ -685,6 +485,7 @@ pub fn cartesian_to_spherical(v: &Vector3<f64>) -> (f64, f64, f64) {
 
 /// Converts the input vector V from Cartesian coordinates to spherical coordinates
 /// Returns ρ, θ, φ where the range ρ is in the units of the input vector and the angles are in radians
+#[allow(clippy::many_single_char_names)]
 pub fn spherical_to_cartesian(range_ρ: f64, θ: f64, φ: f64) -> Vector3<f64> {
     if range_ρ < f64::EPSILON {
         // Treat a negative range as a zero vector
@@ -697,116 +498,12 @@ pub fn spherical_to_cartesian(range_ρ: f64, θ: f64, φ: f64) -> Vector3<f64> {
     }
 }
 
-#[rustfmt::skip]
-#[test]
-fn test_diagonality() {
-    assert!(!is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
-                                       1.0, 5.0, 0.0,
-                                       0.0, 0.0, 2.0)),
-        "lower triangular"
-    );
-    assert!(!is_diagonal(&Matrix3::new(10.0, 1.0, 0.0,
-                                       1.0, 5.0, 0.0,
-                                       0.0, 0.0, 2.0)),
-        "symmetric but not diag"
-    );
-    assert!(!is_diagonal(&Matrix3::new(10.0, 1.0, 0.0,
-                                       0.0, 5.0, 0.0,
-                                       0.0, 0.0, 2.0)),
-        "upper triangular"
-    );
-    assert!(is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
-                                       0.0, 0.0, 0.0,
-                                       0.0, 0.0, 2.0)),
-        "diagonal with zero diagonal element"
-    );
-    assert!(is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
-                                      0.0, 5.0, 0.0,
-                                      0.0, 0.0, 2.0)),
-        "diagonal"
-    );
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+    use nalgebra::{Complex, OVector};
 
-#[test]
-fn test_angle_bounds() {
-    assert!((between_pm_180(181.0) - -179.0).abs() < f64::EPSILON);
-    assert!((between_0_360(-179.0) - 181.0).abs() < f64::EPSILON);
-}
-
-#[test]
-fn test_positive_angle() {
-    assert_eq!(between_0_360(450.0), 90.0);
-    assert_eq!(between_pm_x(270.0, 180.0), -90.0);
-}
-
-#[test]
-fn test_negative_angle() {
-    assert_eq!(between_0_360(-90.0), 270.0);
-    assert_eq!(between_pm_x(-270.0, 180.0), 90.0);
-}
-
-#[test]
-fn test_angle_in_range() {
-    assert_eq!(between_0_360(180.0), 180.0);
-    assert_eq!(between_pm_x(90.0, 180.0), 90.0);
-}
-
-#[test]
-fn test_zero_angle() {
-    assert_eq!(between_0_360(0.0), 0.0);
-    assert_eq!(between_pm_x(0.0, 180.0), 0.0);
-}
-
-#[test]
-fn test_full_circle_angle() {
-    assert_eq!(between_0_360(360.0), 0.0);
-    assert_eq!(between_pm_x(360.0, 180.0), 0.0);
-}
-
-#[test]
-fn test_pseudo_inv() {
-    use crate::linalg::{DMatrix, SMatrix};
-    let mut mat = DMatrix::from_element(1, 3, 0.0);
-    mat[(0, 0)] = -1407.273208782421;
-    mat[(0, 1)] = -2146.3100013104886;
-    mat[(0, 2)] = 84.05022886527551;
-
-    println!("{}", pseudo_inverse!(&mat).unwrap());
-
-    let mut mat = SMatrix::<f64, 1, 3>::zeros();
-    mat[(0, 0)] = -1407.273208782421;
-    mat[(0, 1)] = -2146.3100013104886;
-    mat[(0, 2)] = 84.05022886527551;
-
-    println!("{}", pseudo_inverse!(&mat).unwrap());
-
-    let mut mat = SMatrix::<f64, 3, 1>::zeros();
-    mat[(0, 0)] = -1407.273208782421;
-    mat[(1, 0)] = -2146.3100013104886;
-    mat[(2, 0)] = 84.05022886527551;
-
-    println!("{}", pseudo_inverse!(&mat).unwrap());
-
-    // Compare a pseudo inverse with a true inverse
-    let mat = SMatrix::<f64, 2, 2>::new(3.0, 4.0, -2.0, 1.0);
-    println!("{}", mat.try_inverse().unwrap());
-
-    println!("{}", pseudo_inverse!(&mat).unwrap());
-}
-
-#[test]
-fn spherical() {
-    for v in &[
-        Vector3::<f64>::x(),
-        Vector3::<f64>::y(),
-        Vector3::<f64>::z(),
-        Vector3::<f64>::zeros(),
-        Vector3::<f64>::new(159.1, 561.2, 756.3),
-    ] {
-        let (range_ρ, θ, φ) = cartesian_to_spherical(v);
-        let v_prime = spherical_to_cartesian(range_ρ, θ, φ);
-
-        assert!(rss_errors(v, &v_prime) < 1e-12, "{} != {}", v, &v_prime);
     trait FailureTolerance {
         fn within_tolerance(&self, other: Self) -> bool;
     }
@@ -816,6 +513,41 @@ fn spherical() {
             (self - other).abs() < f64::EPSILON
         }
     }
+
+    #[test]
+    fn test_stable_eigenvalues() {
+        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
+            Complex::new(-1.0, 0.0),
+            Complex::new(0.0, 0.0),
+        ]);
+        assert!(are_eigenvalues_stable(&eigenvalues));
+    }
+
+    #[test]
+    fn test_unstable_eigenvalues() {
+        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
+            Complex::new(1.0, 0.0),
+            Complex::new(0.0, 0.0),
+        ]);
+        assert!(!are_eigenvalues_stable(&eigenvalues));
+    }
+
+    #[test]
+    fn test_oscillatory_eigenvalues() {
+        let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
+            Complex::new(0.0, 1.0),
+            Complex::new(0.0, -1.0),
+        ]);
+        assert!(are_eigenvalues_stable(&eigenvalues));
+    }
+
+    #[test]
+    fn test_invariant_eigenvalues() {
+        let eigenvalues =
+            OVector::<Complex<f64>, nalgebra::U1>::from_column_slice(&[Complex::new(0.0, 0.0)]);
+        assert!(are_eigenvalues_stable(&eigenvalues));
+    }
+
     #[test]
     fn test_angle_bounds() {
         assert!(between_pm_180(181.0).within_tolerance(-179.0));
@@ -853,6 +585,108 @@ fn spherical() {
     }
 
     #[test]
+    fn test_pseudo_inv() {
+        use crate::linalg::{DMatrix, SMatrix};
+        let mut mat = DMatrix::from_element(1, 3, 0.0);
+        mat[(0, 0)] = -1407.273208782421;
+        mat[(0, 1)] = -2146.3100013104886;
+        mat[(0, 2)] = 84.05022886527551;
+
+        println!("{}", pseudo_inverse!(&mat).unwrap());
+
+        let mut mat = SMatrix::<f64, 1, 3>::zeros();
+        mat[(0, 0)] = -1407.273208782421;
+        mat[(0, 1)] = -2146.3100013104886;
+        mat[(0, 2)] = 84.05022886527551;
+
+        println!("{}", pseudo_inverse!(&mat).unwrap());
+
+        let mut mat = SMatrix::<f64, 3, 1>::zeros();
+        mat[(0, 0)] = -1407.273208782421;
+        mat[(1, 0)] = -2146.3100013104886;
+        mat[(2, 0)] = 84.05022886527551;
+
+        println!("{}", pseudo_inverse!(&mat).unwrap());
+
+        // Compare a pseudo inverse with a true inverse
+        let mat = SMatrix::<f64, 2, 2>::new(3.0, 4.0, -2.0, 1.0);
+        println!("{}", mat.try_inverse().unwrap());
+
+        println!("{}", pseudo_inverse!(&mat).unwrap());
+    }
+
+    #[test]
+    fn spherical() {
+        for v in &[
+            Vector3::<f64>::x(),
+            Vector3::<f64>::y(),
+            Vector3::<f64>::z(),
+            Vector3::<f64>::zeros(),
+            Vector3::<f64>::new(159.1, 561.2, 756.3),
+        ] {
+            let (range_ρ, θ, φ) = cartesian_to_spherical(v);
+            let v_prime = spherical_to_cartesian(range_ρ, θ, φ);
+
+            assert!(rss_errors(v, &v_prime) < 1e-12, "{} != {}", v, &v_prime);
+        }
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_diagonality() {
+        assert!(!is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
+                                           1.0, 5.0, 0.0,
+                                           0.0, 0.0, 2.0)),
+            "lower triangular"
+        );
+        assert!(!is_diagonal(&Matrix3::new(10.0, 1.0, 0.0,
+                                           1.0, 5.0, 0.0,
+                                           0.0, 0.0, 2.0)),
+            "symmetric but not diag"
+        );
+        assert!(!is_diagonal(&Matrix3::new(10.0, 1.0, 0.0,
+                                           0.0, 5.0, 0.0,
+                                           0.0, 0.0, 2.0)),
+            "upper triangular"
+        );
+        assert!(is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
+                                           0.0, 0.0, 0.0,
+                                           0.0, 0.0, 2.0)),
+            "diagonal with zero diagonal element"
+        );
+        assert!(is_diagonal(&Matrix3::new(10.0, 0.0, 0.0,
+                                          0.0, 5.0, 0.0,
+                                          0.0, 0.0, 2.0)),
+            "diagonal"
+        );
+    }
+
+    #[test]
+    fn test_projv() {
+        assert_eq!(
+            projv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(2.0, 0.0, 0.0)),
+            Vector3::new(6.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            projv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(-3.0, 0.0, 0.0)),
+            Vector3::new(6.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            projv(&Vector3::new(6.0, 6.0, 0.0), &Vector3::new(0.0, 7.0, 0.0)),
+            Vector3::new(0.0, 6.0, 0.0)
+        );
+        assert_eq!(
+            projv(&Vector3::new(6.0, 0.0, 0.0), &Vector3::new(0.0, 0.0, 9.0)),
+            Vector3::new(0.0, 0.0, 0.0)
+        );
+
+        let a = Vector3::new(1.0, 1.0, 0.0);
+        let b = Vector3::new(1.0, 0.0, 0.0);
+        let result = projv(&a, &b);
+        assert_abs_diff_eq!(result, Vector3::new(1.0, 0.0, 0.0), epsilon = 1e-7);
+    }
+
+    #[test]
     fn test_rss_errors() {
         use nalgebra::U3;
         let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
@@ -883,6 +717,45 @@ fn spherical() {
     }
 
     #[test]
+    fn test_capitalize() {
+        let s = "hello";
+        let result = capitalize(s);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn test_r2() {
+        let angle = 0.0;
+        let rotation_matrix = r2(angle);
+        assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
+
+        let angle = std::f64::consts::PI / 2.0;
+        let rotation_matrix = r2(angle);
+        let expected_matrix = Matrix3::new(0.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0);
+        assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
+
+        let v = Vector3::new(0.0, 1.0, 0.0);
+        let rotated_v = rotation_matrix * v;
+        assert!((rotated_v - v).norm() <= f64::EPSILON);
+    }
+
+    #[test]
+    fn test_r1() {
+        let angle = 0.0;
+        let rotation_matrix = r1(angle);
+        assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
+
+        let angle = std::f64::consts::PI / 2.0;
+        let rotation_matrix = r1(angle);
+        let expected_matrix = Matrix3::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0);
+        assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
+
+        let v = Vector3::new(1.0, 0.0, 0.0);
+        let rotated_v = rotation_matrix * v;
+        assert!((rotated_v - v).norm() <= f64::EPSILON);
+    }
+
+    #[test]
     fn test_tilde_matrix() {
         let vec = Vector3::new(1.0, 2.0, 3.0);
         let rslt = Matrix3::new(0.0, -3.0, 2.0, 3.0, 0.0, -1.0, -2.0, 1.0, 0.0);
@@ -902,5 +775,53 @@ fn spherical() {
         assert!(m[(2, 2)].within_tolerance(0.0));
     }
 
+    #[test]
+    fn test_perpv() {
+        assert_eq!(
+            perpv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(2.0, 0.0, 0.0)),
+            Vector3::new(0.0, 6.0, 6.0)
+        );
+        assert_eq!(
+            perpv(&Vector3::new(6.0, 6.0, 6.0), &Vector3::new(-3.0, 0.0, 0.0)),
+            Vector3::new(0.0, 6.0, 6.0)
+        );
+        assert_eq!(
+            perpv(&Vector3::new(6.0, 6.0, 0.0), &Vector3::new(0.0, 7.0, 0.0)),
+            Vector3::new(6.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            perpv(&Vector3::new(6.0, 0.0, 0.0), &Vector3::new(0.0, 0.0, 9.0)),
+            Vector3::new(6.0, 0.0, 0.0)
+        );
+        let a = Vector3::new(1.0, 1.0, 0.0);
+        let b = Vector3::new(1.0, 0.0, 0.0);
+        let result = perpv(&a, &b);
+        assert_abs_diff_eq!(result, Vector3::new(0.0, 1.0, 0.0), epsilon = 1e-7);
+    }
+
+    #[test]
+    fn test_r3() {
+        let angle = 0.0;
+        let rotation_matrix = r3(angle);
+        assert!((rotation_matrix - Matrix3::identity()).abs().max() <= f64::EPSILON);
+
+        let angle = std::f64::consts::PI / 2.0;
+        let rotation_matrix = r3(angle);
+        let expected_matrix = Matrix3::new(0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+        assert!((rotation_matrix - expected_matrix).abs().max() <= f64::EPSILON);
+
+        let v = Vector3::new(0.0, 0.0, 1.0);
+        let rotated_v = rotation_matrix * v;
+        assert!((rotated_v - v).norm() <= f64::EPSILON);
+    }
+
+    #[test]
+    fn test_rotv() {
+        use approx::assert_abs_diff_eq;
+        let v = Vector3::new(1.0, 0.0, 0.0);
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let theta = std::f64::consts::PI / 2.0;
+        let result = rotv(&v, &axis, theta);
+        assert_abs_diff_eq!(result, Vector3::new(0.0, 1.0, 0.0), epsilon = 1e-7);
     }
 }

--- a/nyx-core/src/utils.rs
+++ b/nyx-core/src/utils.rs
@@ -39,7 +39,6 @@ pub fn tilde_matrix(v: &Vector3<f64>) -> Matrix3<f64> {
     Matrix3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
 }
 
-
 /// Checks if the provided 3x3 matrix is diagonal.
 ///
 /// A square matrix is considered diagonal if all its off-diagonal elements are zero.
@@ -106,7 +105,7 @@ pub fn is_diagonal(m: &Matrix3<f64>) -> bool {
 /// use nalgebra::Complex;
 ///
 /// let eigenvalues = Vector2::new(Complex::new(-1.0, 0.0), Complex::new(0.0, 1.0));
-/// assert_eq!(are_eigenvalues_stable(eigenvalues), true);
+/// assert_eq!(are_eigenvalues_stable(&eigenvalues), true);
 /// ```
 /// # Source
 ///
@@ -117,7 +116,6 @@ where
 {
     eigenvalues.iter().all(|ev| ev.re <= 0.0)
 }
-
 
 /// Returns the provided angle bounded between 0.0 and 360.0.
 ///
@@ -277,7 +275,6 @@ pub fn rotv(v: &Vector3<f64>, axis: &Vector3<f64>, theta: f64) -> Vector3<f64> {
         + k_hat.scale(k_hat.dot(v) * (1.0 - theta.cos()))
 }
 
-
 /// Returns the components of vector a orthogonal to b
 ///
 /// # Arguments
@@ -303,7 +300,6 @@ pub fn perpv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
     }
 }
 
-
 /// Returns the projection of a onto b
 ///
 /// # Arguments
@@ -322,7 +318,6 @@ pub fn projv(a: &Vector3<f64>, b: &Vector3<f64>) -> Vector3<f64> {
         b.scale(a.dot(b) / b_norm_squared)
     }
 }
-
 
 /// Computes the Root Sum Squared (RSS) state errors between two provided vectors.
 ///
@@ -430,7 +425,6 @@ pub fn capitalize(s: &str) -> String {
     }
 }
 
-
 #[macro_export]
 macro_rules! pseudo_inverse {
     ($mat:expr) => {{
@@ -504,16 +498,6 @@ mod tests {
     use approx::assert_abs_diff_eq;
     use nalgebra::{Complex, OVector};
 
-    trait FailureTolerance {
-        fn within_tolerance(&self, other: Self) -> bool;
-    }
-
-    impl FailureTolerance for f64 {
-        fn within_tolerance(&self, other: Self) -> bool {
-            (self - other).abs() < f64::EPSILON
-        }
-    }
-
     #[test]
     fn test_stable_eigenvalues() {
         let eigenvalues = OVector::<Complex<f64>, nalgebra::U2>::from_column_slice(&[
@@ -550,38 +534,38 @@ mod tests {
 
     #[test]
     fn test_angle_bounds() {
-        assert!(between_pm_180(181.0).within_tolerance(-179.0));
-        assert!(between_0_360(-179.0).within_tolerance(181.0));
+        approx::assert_relative_eq!(between_pm_180(181.0), -179.0);
+        approx::assert_relative_eq!(between_0_360(-179.0), 181.0);
     }
 
     #[test]
     fn test_positive_angle() {
-        assert!(between_0_360(450.0).within_tolerance(90.0));
-        assert!(between_pm_x(270.0, 180.0).within_tolerance(-90.0));
+        approx::assert_relative_eq!(between_0_360(450.0), 90.0);
+        approx::assert_relative_eq!(between_pm_x(270.0, 180.0), -90.0);
     }
 
     #[test]
     fn test_negative_angle() {
-        assert!(between_0_360(-90.0).within_tolerance(270.0));
-        assert!(between_pm_x(-270.0, 180.0).within_tolerance(90.0));
+        approx::assert_relative_eq!(between_0_360(-90.0), 270.0);
+        approx::assert_relative_eq!(between_pm_x(-270.0, 180.0), 90.0);
     }
 
     #[test]
     fn test_angle_in_range() {
-        assert!(between_0_360(180.0).within_tolerance(180.0));
-        assert!(between_pm_x(90.0, 180.0).within_tolerance(90.0));
+        approx::assert_relative_eq!(between_0_360(180.0), 180.0);
+        approx::assert_relative_eq!(between_pm_x(90.0, 180.0), 90.0);
     }
 
     #[test]
     fn test_zero_angle() {
-        assert!(between_0_360(0.0).within_tolerance(0.0));
-        assert!(between_pm_x(0.0, 180.0).within_tolerance(0.0));
+        approx::assert_relative_eq!(between_0_360(0.0), 0.0);
+        approx::assert_relative_eq!(between_pm_x(0.0, 180.0), 0.0);
     }
 
     #[test]
     fn test_full_circle_angle() {
-        assert!(between_0_360(360.0).within_tolerance(0.0));
-        assert!(between_pm_x(360.0, 180.0).within_tolerance(0.0));
+        approx::assert_relative_eq!(between_0_360(360.0), 0.0);
+        approx::assert_relative_eq!(between_pm_x(360.0, 180.0), 0.0);
     }
 
     #[test]
@@ -691,11 +675,11 @@ mod tests {
         use nalgebra::U3;
         let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
         let cur_state = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
-        assert!(rss_errors(&prop_err, &cur_state).within_tolerance(0.0));
+        approx::assert_relative_eq!(rss_errors(&prop_err, &cur_state), 0.0);
 
         let prop_err = OVector::<f64, U3>::from_iterator([1.0, 2.0, 3.0]);
         let cur_state = OVector::<f64, U3>::from_iterator([4.0, 5.0, 6.0]);
-        assert!(rss_errors(&prop_err, &cur_state).within_tolerance(5.196152422706632));
+        approx::assert_relative_eq!(rss_errors(&prop_err, &cur_state), 5.196152422706632);
     }
 
     #[test]
@@ -704,7 +688,7 @@ mod tests {
         let min_x = 0.0;
         let max_x = 10.0;
         let result = normalize(x, min_x, max_x);
-        assert!(result.within_tolerance(0.0));
+        approx::assert_relative_eq!(result, 0.0);
     }
 
     #[test]
@@ -713,7 +697,7 @@ mod tests {
         let min_x = 0.0;
         let max_x = 10.0;
         let result = denormalize(xp, min_x, max_x);
-        assert!(result.within_tolerance(5.0));
+        approx::assert_relative_eq!(result, 5.0);
     }
 
     #[test]
@@ -764,15 +748,15 @@ mod tests {
         let v = Vector3::new(1.0, 2.0, 3.0);
         let m = tilde_matrix(&v);
 
-        assert!(m[(0, 0)].within_tolerance(0.0));
-        assert!(m[(0, 1)].within_tolerance(-v.z));
-        assert!(m[(0, 2)].within_tolerance(v.y));
-        assert!(m[(1, 0)].within_tolerance(v.z));
-        assert!(m[(1, 1)].within_tolerance(0.0));
-        assert!(m[(1, 2)].within_tolerance(-v.x));
-        assert!(m[(2, 0)].within_tolerance(-v.y));
-        assert!(m[(2, 1)].within_tolerance(v.x));
-        assert!(m[(2, 2)].within_tolerance(0.0));
+        approx::assert_relative_eq!(m[(0, 0)], 0.0);
+        approx::assert_relative_eq!(m[(0, 1)], -v.z);
+        approx::assert_relative_eq!(m[(0, 2)], v.y);
+        approx::assert_relative_eq!(m[(1, 0)], v.z);
+        approx::assert_relative_eq!(m[(1, 1)], 0.0);
+        approx::assert_relative_eq!(m[(1, 2)], -v.x);
+        approx::assert_relative_eq!(m[(2, 0)], -v.y);
+        approx::assert_relative_eq!(m[(2, 1)], v.x);
+        approx::assert_relative_eq!(m[(2, 2)], 0.0);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

In an effort to learn this codebase, this is a PR about improving organization in the utils file. A refactor of the tests into their own module and more effective use of a Trait for clarity in the code.

To discover potential improvements, I ran clippy with pedantic level lints (`cargo clippy -- -W clippy::pedantic`). However, this resulted in over 1000 warnings, far too much for an initial pull request into a repo by an unknown developer. So instead I limited the changes to just a single file (`utils.rs`).

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation


I made the changes in two commits:
1. The primary linting suggestion was to stop comparing f64 to each other. The codebase already had an example of the preferred method, comparing floats with a tolerance (this was the `(x - y).abs() < f64::Epislon)` pattern. I formalized this into a trait called FailureTolerance and refactored the tests to use it.
2. After this, the tests were spread out across the file. I bundled them together into a tests module (which was already one of the existing patterns).
 
**Detail the changes in tests, including new tests and validations**

```rust
trait FailureTolerance {
    fn within_tolerance(&self, other: Self) -> bool;
}

impl FailureTolerance for f64 {
    fn within_tolerance(&self, other: Self) -> bool {
        (self - other).abs() < f64::EPSILON
    }
}
```

This trait is only defined within the new testing module (and will therefore not increase the compile time during release builds), and allows for a nicer (I think) pattern in the tests.

Old:

```rust
#[test]
fn test_angle_bounds() {
    assert!((between_pm_180(181.0) - -179.0).abs() < f64::EPSILON);
    assert!((between_0_360(-179.0) - 181.0).abs() < f64::EPSILON);
}
```

New:

```rust
#[test]
fn test_angle_bounds() {
    assert!(between_pm_180(181.0).within_tolerance(-179.0));
    assert!(between_0_360(-179.0).within_tolerance(181.0));
}
```
## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->