### PR TITLE
Fix missing Windows and macOS Python wheels on PyPI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.target }}
-          path: dist
+          path: nyx-py/dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
+          path: nyx-py/dist
 
   # Nyx does NOT provide the source for manual compilation on unavailable platforms on purpose.
   # sdist:


### PR DESCRIPTION
Updated the GitHub Actions workflow for Python to correctly locate built wheels for Windows and macOS. The previous configuration was looking for them in the root directory instead of the `nyx-py/dist` directory where they are generated.

Fixes #569

---
*PR created automatically by Jules for task [11628065646044592646](https://jules.google.com/task/11628065646044592646) started by @ChristopherRabotin*