### PR TITLE
Add NormalizedConsistency struct for NIS and NEES

### DIFF
--- a/nyx-core/examples/06_lunar_orbit_determination/main.rs
+++ b/nyx-core/examples/06_lunar_orbit_determination/main.rs
@@ -228,7 +228,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         od_sol.residual_ratio_within_threshold(3.0).unwrap()
     );
     println!("Whitened residuals normal? {}", od_sol.is_normal(None)?);
-    println!("NIS test success? {}", od_sol.is_nis_consistent(None)?);
+    println!("NIS consistency: {}", od_sol.nis_consistency(None)?);
 
     od_sol.to_parquet(
         "./data/04_output/06_lunar_od_results.parquet",

--- a/nyx-core/src/od/mod.rs
+++ b/nyx-core/src/od/mod.rs
@@ -111,6 +111,7 @@ pub mod prelude {
     pub use super::simulator::*;
     pub use super::snc::*;
     pub use super::*;
+    pub use crate::od::process::NormalizedConsistency;
 
     pub use crate::time::{Duration, Epoch, TimeUnits, Unit};
 }

--- a/nyx-core/src/od/process/mod.rs
+++ b/nyx-core/src/od/process/mod.rs
@@ -41,7 +41,7 @@ use self::kalman::KalmanFilter;
 use self::msr::TrackingDataArc;
 pub use self::rejectcrit::SigmaRejection;
 mod solution;
-pub use solution::ODSolution;
+pub use solution::{NormalizedConsistency, ODSolution};
 mod initializers;
 
 /// An orbit determination process (ODP) which filters OD measurements through a Kalman filter.

--- a/nyx-core/src/od/process/solution/mod.rs
+++ b/nyx-core/src/od/process/solution/mod.rs
@@ -38,6 +38,8 @@ mod import;
 mod smooth;
 mod stats;
 
+pub use stats::NormalizedConsistency;
+
 /// The `ODSolution` structure is designed to manage and analyze the results of an OD process, including
 /// smoothing. It provides various functionalities such as splitting solutions by tracker or measurement type,
 /// joining solutions, and performing statistical analyses.

--- a/nyx-core/src/od/process/solution/smooth.rs
+++ b/nyx-core/src/od/process/solution/smooth.rs
@@ -17,13 +17,14 @@
 */
 
 use crate::linalg::allocator::Allocator;
-use crate::linalg::{DefaultAllocator, DimName, OMatrix};
+use crate::linalg::{DefaultAllocator, DimName};
 use crate::md::trajectory::Interpolatable;
 pub use crate::od::estimate::*;
 pub use crate::od::*;
 use anise::prelude::Almanac;
 use log::info;
 use msr::sensitivity::TrackerSensitivity;
+use nalgebra::DimMin;
 use std::ops::Add;
 
 use super::ODSolution;
@@ -34,6 +35,7 @@ where
     EstType: Estimate<StateType>,
     MsrSize: DimName,
     Trk: TrackerSensitivity<StateType, StateType>,
+    <StateType as State>::Size: DimMin<<StateType as State>::Size>,
     <DefaultAllocator as Allocator<<StateType as State>::VecLength>>::Buffer<f64>: Send,
     DefaultAllocator: Allocator<<StateType as State>::Size>
         + Allocator<<StateType as State>::VecLength>
@@ -41,7 +43,8 @@ where
         + Allocator<MsrSize, <StateType as State>::Size>
         + Allocator<MsrSize, MsrSize>
         + Allocator<<StateType as State>::Size, <StateType as State>::Size>
-        + Allocator<<StateType as State>::Size, MsrSize>,
+        + Allocator<<StateType as State>::Size, MsrSize>
+        + Allocator<<<StateType as State>::Size as DimMin<<StateType as State>::Size>>::Output>,
 {
     /// Smoothes this OD solution, returning a new OD solution and the filter-smoother consistency ratios, with updated **postfit** residuals, and where the ratio now represents the filter-smoother consistency ratio.
     ///
@@ -98,7 +101,11 @@ where
     /// - If $ |R_{i,k}| \leq 3 $ for all $ i $ and $ k $, the filter-smoother consistency test is satisfied, indicating good consistency.
     /// - If $ |R_{i,k}| > 3 $ for any $ i $ or $ k $, the test fails, suggesting potential modeling inconsistencies or issues with the estimation process.
     ///
-    pub fn smooth(self, almanac: &Almanac) -> Result<Self, ODError> {
+    pub fn smooth(self, almanac: &Almanac) -> Result<Self, ODError>
+    where
+        <StateType as State>::Size:
+            DimMin<<StateType as State>::Size, Output = <StateType as State>::Size>,
+    {
         let l = self.estimates.len() - 1;
 
         let mut smoothed = Self {
@@ -135,26 +142,14 @@ where
             // The filter will reset the STM between each estimate it computes, time update or measurement update.
             // Therefore, the STM is simply the inverse of the one we used previously.
             // est_kp1 is the estimate that used the STM from time k to time k+1. So the STM stored there
-            // is \Phi_{k \to k+1}. Let's invert that via a UDU decomposition for stability.
-            let phi_kp1_k = match est_kp1.stm().clone().udu() {
-                Some(stm_udu) => {
-                    // Invert both parts
-                    match stm_udu.u.try_inverse() {
-                        None => return Err(ODError::SingularStateTransitionMatrix),
-                        Some(u_inv) => {
-                            let d_inv = OMatrix::from_diagonal(&OVector::<
-                                f64,
-                                <StateType as State>::Size,
-                            >::from_iterator(
-                                stm_udu.d.iter().map(|d_ii| 1.0 / d_ii),
-                            ));
-                            let y = d_inv * &u_inv;
-                            u_inv.transpose() * y
-                        }
-                    }
-                }
-                None => return Err(ODError::SingularStateTransitionMatrix),
-            };
+            // is \Phi_{k \to k+1}.
+            // We invert via LU decomposition because the STM is not PSD, so neither Cholesky nor UDU work.
+            let phi_kp1_k = est_kp1
+                .stm()
+                .clone()
+                .lu()
+                .try_inverse()
+                .ok_or(ODError::SingularStateTransitionMatrix)?;
 
             // Compute smoothed state deviation
             let x_k_l = &phi_kp1_k * x_kp1_l;

--- a/nyx-core/src/od/process/solution/stats.rs
+++ b/nyx-core/src/od/process/solution/stats.rs
@@ -17,18 +17,121 @@
 */
 
 use crate::linalg::allocator::Allocator;
-use crate::linalg::{DefaultAllocator, DimMin, DimName, DimSub};
+use crate::linalg::{Const, DMatrix, DefaultAllocator, DimMin, DimName, DimSub, OVector};
 use crate::md::trajectory::{Interpolatable, Traj};
 pub use crate::od::estimate::*;
 pub use crate::od::*;
-use log::warn;
+use log::{info, warn};
 use msr::sensitivity::TrackerSensitivity;
-use nalgebra::Const;
 use snafu::ResultExt;
 use statrs::distribution::{ContinuousCDF, Normal};
+use std::fmt;
 use std::ops::Add;
 
 use super::ODSolution;
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg_attr(feature = "python", pyclass(from_py_object, get_all))]
+#[derive(Copy, Clone, Debug)]
+pub struct NormalizedConsistency {
+    pub normalized_sum: f64,
+    pub k: f64,
+    pub lower_bound: f64,
+    pub upper_bound: f64,
+    pub is_nees: bool,
+}
+
+#[cfg_attr(feature = "python", pymethods)]
+impl NormalizedConsistency {
+    pub fn name(&self) -> &'static str {
+        if self.is_nees {
+            "NEES"
+        } else {
+            "NIS"
+        }
+    }
+
+    /// Returns true if there are more than 35 degrees of freedom
+    pub fn has_statistical_power(&self) -> bool {
+        self.k > 35.0
+    }
+
+    /// Returns true if the sum metric is within the lower and upper bounds
+    pub fn is_consistent(&self) -> bool {
+        self.normalized_sum < self.upper_bound && self.normalized_sum > self.lower_bound
+    }
+
+    /// Returns true if the normalized sum is less than the lower bound
+    pub fn is_underconfident(&self) -> bool {
+        self.normalized_sum < self.lower_bound
+    }
+
+    /// Returns true if the normalized sum is greater than the upper bound
+    pub fn is_overconfident(&self) -> bool {
+        self.normalized_sum > self.upper_bound
+    }
+
+    /// Log the status to the logger
+    pub fn log(&self) {
+        let name = self.name();
+        let sum = self.normalized_sum;
+        let upper_bound = self.upper_bound;
+        let lower_bound = self.lower_bound;
+        if sum > upper_bound {
+            warn!(
+                "{name} consistency test failed high: {name} sum {sum:.3} > upper bound {upper_bound:.3}."
+            );
+            if self.is_nees {
+                warn!("Estimation errors are larger than the covariance suggests.");
+            } else {
+                warn!("Innovations are larger than expected");
+            }
+            warn!(
+                "Filter is overconfident: P, R, or Q may be too small, or the dynamics/measurement model may be biased."
+            );
+        } else if sum < lower_bound {
+            warn!(
+                "{name} consistency test failed low: {name} sum {sum:.3} < lower bound {lower_bound:.3}."
+            );
+            if self.is_nees {
+                warn!("Estimation errors are smaller than expected.");
+            } else {
+                warn!("Innovations are smaller than expected.")
+            }
+            warn!("Filter is underconfident: P, R, or Q may be too large.");
+        } else {
+            info!("{name} passed")
+        }
+    }
+
+    #[cfg(feature = "python")]
+    fn __str__(&self) -> String {
+        format!("{self}")
+    }
+
+    #[cfg(feature = "python")]
+    fn __repr__(&self) -> String {
+        format!("{self} @ {self:p}")
+    }
+}
+
+impl fmt::Display for NormalizedConsistency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let is_ok = self.is_consistent();
+        write!(
+            f,
+            "{} consistency {} (k={}; bounds: {:.3} < {:.3} < {:.3})",
+            self.name(),
+            if is_ok { "PASSED" } else { "FAILED" },
+            self.k,
+            self.lower_bound,
+            self.normalized_sum,
+            self.upper_bound
+        )
+    }
+}
 
 impl<StateType, EstType, MsrSize, Trk> ODSolution<StateType, EstType, MsrSize, Trk>
 where
@@ -144,7 +247,7 @@ where
     /// Returns Ok(true) if the residuals are consistent with a normal distribution,
     /// Ok(false) if not, or None if no residuals are available.
     pub fn is_normal(&self, alpha: Option<f64>) -> Result<bool, ODError> {
-        let n = self.residuals.iter().flatten().count();
+        let n = self.accepted_residuals().len();
         if n == 0 {
             return Err(ODError::ODNoResiduals {
                 action: "evaluating residual normality",
@@ -152,6 +255,7 @@ where
         } else if n < 35 {
             warn!("KS normality test unreliable for n={n} < 35; skipping");
         }
+
         let ks_stat = self.ks_test_normality()?;
 
         // Default to 5% probability
@@ -179,7 +283,7 @@ where
     ///
     /// Returns Ok(true) if the filter is consistent, Ok(false) if the filter
     /// is over-confident or under-confident, or an error if no residuals are available.
-    pub fn is_nis_consistent(&self, alpha: Option<f64>) -> Result<bool, ODError> {
+    pub fn nis_consistency(&self, alpha: Option<f64>) -> Result<NormalizedConsistency, ODError> {
         let n = self.accepted_residuals().len();
 
         if n == 0 {
@@ -214,23 +318,13 @@ where
         let lower_bound = k * (1.0 - factor - z_critical * factor.sqrt()).powi(3);
         let upper_bound = k * (1.0 - factor + z_critical * factor.sqrt()).powi(3);
 
-        if nis_sum > upper_bound {
-            warn!(
-                "NIS consistency test failed high: NIS sum {nis_sum:.6} > upper bound {upper_bound:.6}. Innovations are larger than expected."
-            );
-            warn!(
-                "Filter may be overconfident: P, R, or Q may be too small, or the dynamics/measurement model may be biased."
-            );
-            Ok(false)
-        } else if nis_sum < lower_bound {
-            warn!(
-                "NIS consistency test failed low: NIS sum {nis_sum:.6} < lower bound {lower_bound:.6}. Innovations are smaller than expected."
-            );
-            warn!("Filter may be underconfident: P, R, or Q may be too large.");
-            Ok(false)
-        } else {
-            Ok(true)
-        }
+        Ok(NormalizedConsistency {
+            normalized_sum: nis_sum,
+            lower_bound,
+            upper_bound,
+            k,
+            is_nees: false,
+        })
     }
 
     /// Checks whether the filter estimates are statistically consistent
@@ -245,15 +339,12 @@ where
     ///
     /// The sum of NEES values should fall within the confidence interval of a
     /// Chi-squared distribution with degrees of freedom `k = n * dim`, where `n`
-    /// is the number of estimates and `dim` is the state dimension.
-    ///
-    /// Returns Ok(true) if the filter is consistent, Ok(false) if the filter
-    /// is over-confident or under-confident, or an error if no estimates are available.
-    pub fn is_nees_consistent(
+    /// is the number of estimates and `dim` is the actively estimated state dimension.
+    pub fn nees_consistency(
         &self,
         truth_traj: &Traj<StateType>,
         alpha: Option<f64>,
-    ) -> Result<bool, ODError>
+    ) -> Result<NormalizedConsistency, ODError>
     where
         StateType::Size: DimMin<StateType::Size>,
         <StateType::Size as DimMin<StateType::Size>>::Output: DimSub<Const<1>>,
@@ -268,18 +359,22 @@ where
                 <<StateType::Size as DimMin<StateType::Size>>::Output as DimSub<Const<1>>>::Output,
             >,
     {
-        let n = self.estimates.len();
+        let n_total = self.estimates.len();
 
-        if n == 0 {
+        // We will skip the apriori estimate.
+        if n_total <= 1 {
             return Err(ODError::ODNoResiduals {
                 action: "evaluating NEES consistency",
             });
         }
 
-        let mut nees_sum = 0.0;
-        let mut state_dim_f64 = 0.0_f64;
+        // The exact number of epochs evaluated in the NEES sum
+        let n = n_total - 1;
 
-        for est in &self.estimates {
+        let mut nees_sum = 0.0;
+        let mut est_size = None;
+
+        for est in self.estimates.iter().skip(1) {
             let epoch = est.epoch();
 
             let truth_state = truth_traj.at(epoch).context(ODTrajSnafu {
@@ -290,43 +385,72 @@ where
             let x_est = est.state().to_state_vector();
             let x_true = truth_state.to_state_vector();
             let error = x_est - x_true;
+            let cov = est.covar();
+            let cov = 0.5 * (&cov + cov.transpose());
 
-            // Extract the covariance and compute its inverse
-            // Extract the covariance
-            let p_mat = est.covar();
-
-            // Compute the Singular Value Decomposition (SVD) instead of ivnerting as-is.
-            // This enables support for non-estimated parameters.
-            let svd = p_mat.svd(true, true);
-
-            // Define a small tolerance for zero-variance detection
-            let epsilon = 1e-12;
-
-            // Compute the Moore-Penrose pseudo-inverse
-            let p_inv = svd
-                .clone()
-                .pseudo_inverse(epsilon)
-                .map_err(|_| ODError::SingularInformationMatrix)?;
-
-            // Dynamically determine the rank (number of actively estimated parameters)
-            // nalgebra's SVD provides a built-in rank evaluation
-            let active_dim = svd.rank(epsilon) as f64;
-
-            // Update the computed degree of freedom, it's fixed but the SVD might cause weird rounding
-            state_dim_f64 = state_dim_f64.max(active_dim);
-
-            // Compute NEES for this epoch: error^T * P^+ * error
-            let nees_matrix = error.transpose() * p_inv * &error;
-            nees_sum += nees_matrix[(0, 0)];
-
-            // Capture the state dimension for the degrees of freedom calculation
-            if state_dim_f64 == 0.0 {
-                state_dim_f64 = error.nrows() as f64;
+            if est_size.is_none() {
+                // Deduce est_size by physically inspecting the diagonal variances.
+                // Unestimated deterministic parameters will have zero variance.
+                let mut active_count = 0;
+                for i in 0..StateType::Size::dim() {
+                    // Check if variance is strictly positive
+                    if cov[(i, i)] > 0.0 {
+                        active_count += 1;
+                    } else {
+                        // Estimated parameters are contiguous from index 0
+                        break;
+                    }
+                }
+                if active_count < 6 {
+                    warn!("Detected est_size of {active_count} < 6; forcing bound to 6");
+                    active_count = 6;
+                }
+                est_size = Some(active_count);
             }
+
+            // At this point, est_size is set and is valid
+            let true_est_size = est_size.unwrap();
+
+            // Dynamically slice the actively estimated block
+            let cov_e = cov
+                .view((0, 0), (true_est_size, true_est_size))
+                .into_owned();
+            let err_e = error.rows(0, true_est_size).into_owned();
+
+            // Execute Symmetric Eigendecomposition.
+            // This is mathematically safe because cov was forced to be symmetric via 0.5 * (P + P^T)
+            let eigen = cov_e.symmetric_eigen();
+
+            // Define the numerical noise floor relative to the largest valid physical variance
+            let max_lambda = eigen.eigenvalues.max();
+            let epsilon = max_lambda * (true_est_size as f64) * std::f64::EPSILON;
+
+            // Construct the inverted eigenvalue spectrum
+            let mut inv_eigenvalues = eigen.eigenvalues.clone();
+            for i in 0..true_est_size {
+                // By strictly checking > epsilon, we explicitly trap BOTH:
+                // 1. Positive numerical noise (e.g., +1e-19)
+                // 2. Severe negative numerical drift (e.g., -1e-5)
+                if inv_eigenvalues[i] > epsilon {
+                    inv_eigenvalues[i] = 1.0 / inv_eigenvalues[i];
+                } else {
+                    // Clamp corrupted non-PSD subspaces exactly to zero
+                    inv_eigenvalues[i] = 0.0;
+                }
+            }
+
+            // Reconstruct the symmetric positive semi-definite pseudo-inverse: P^+ = Q * Lambda^+ * Q^T
+            let p_inv = &eigen.eigenvectors
+                * DMatrix::from_diagonal(&inv_eigenvalues)
+                * eigen.eigenvectors.transpose();
+
+            // Compute quadratic form: e^T * P^+ * e
+            let nees_matrix = err_e.transpose() * p_inv * err_e;
+            nees_sum += nees_matrix[(0, 0)];
         }
 
-        // Total degrees of freedom: number of estimates * state dimension
-        let k = (n as f64) * state_dim_f64;
+        // Total degrees of freedom: N evaluated epochs * actively estimated dimension
+        let k = (n * est_size.unwrap()) as f64;
 
         if k < 35.0 {
             warn!("NEES consistency test lacks statistical power for n*StateDim={k} < 35");
@@ -340,30 +464,17 @@ where
             .unwrap()
             .inverse_cdf(1.0 - alpha / 2.0);
 
-        // Use the Wilson-Hilferty transformation to approximate the Chi-squared
-        // lower and upper critical bounds.
+        // Use the Wilson-Hilferty transformation to approximate the Chi-squared lower and upper critical bounds.
         let factor = 2.0 / (9.0 * k);
         let lower_bound = k * (1.0 - factor - z_critical * factor.sqrt()).powi(3);
         let upper_bound = k * (1.0 - factor + z_critical * factor.sqrt()).powi(3);
 
-        if nees_sum > upper_bound {
-            warn!(
-                "NEES consistency test failed high: NEES sum {nees_sum:.6} > upper bound {upper_bound:.6}. Estimation errors are larger than the covariance suggests."
-            );
-            warn!(
-                "Filter is overconfident: P is too small. Process noise Q may be too low, or there are unmodeled dynamic biases."
-            );
-            Ok(false)
-        } else if nees_sum < lower_bound {
-            warn!(
-                "NEES consistency test failed low: NEES sum {nees_sum:.6} < lower bound {lower_bound:.6}. Estimation errors are smaller than expected."
-            );
-            warn!(
-                "Filter is underconfident: P is too large. Process noise Q may be too high, or measurement noise R is overestimated."
-            );
-            Ok(false)
-        } else {
-            Ok(true)
-        }
+        Ok(NormalizedConsistency {
+            normalized_sum: nees_sum,
+            lower_bound,
+            upper_bound,
+            k,
+            is_nees: true,
+        })
     }
 }

--- a/nyx-core/src/od/process/solution/stats.rs
+++ b/nyx-core/src/od/process/solution/stats.rs
@@ -423,7 +423,7 @@ where
 
             // Define the numerical noise floor relative to the largest valid physical variance
             let max_lambda = eigen.eigenvalues.max();
-            let epsilon = max_lambda * (true_est_size as f64) * std::f64::EPSILON;
+            let epsilon = max_lambda * (true_est_size as f64) * f64::EPSILON;
 
             // Construct the inverted eigenvalue spectrum
             let mut inv_eigenvalues = eigen.eigenvalues.clone();

--- a/nyx-core/tests/orbit_determination/spacecraft.rs
+++ b/nyx-core/tests/orbit_determination/spacecraft.rs
@@ -456,15 +456,9 @@ fn od_val_sc_srp_estimation(
         od_sol.residual_ratio_within_threshold(3.0).unwrap()
     );
     println!("Ratios normal? {}", od_sol.is_normal(None).unwrap());
-    println!(
-        "NIS test passed? {}",
-        od_sol.is_nis_consistent(None).unwrap()
-    );
+    println!("NIS: {}", od_sol.nis_consistency(None).unwrap());
     // NEES test, using the truth trajectory
-    println!(
-        "NEES test passed? {}",
-        od_sol.is_nees_consistent(&traj, None).unwrap()
-    );
+    println!("NEES {}", od_sol.nees_consistency(&traj, None).unwrap());
 
     // Regression tests, not solution test
     assert_eq!(

--- a/nyx-py/nyx_space/orbit_determination.pyi
+++ b/nyx-py/nyx_space/orbit_determination.pyi
@@ -826,6 +826,24 @@ class SpacecraftEstimate:
         """Returns whether this estimate is within some bound
         The 68-95-99.7 rule is a good way to assess whether the filter is operating normally"""
 
+    def __eq__(self, value: typing.Any) -> bool:
+        """Return self==value."""
+
+    def __ge__(self, value: typing.Any) -> bool:
+        """Return self>=value."""
+
+    def __gt__(self, value: typing.Any) -> bool:
+        """Return self>value."""
+
+    def __le__(self, value: typing.Any) -> bool:
+        """Return self<=value."""
+
+    def __lt__(self, value: typing.Any) -> bool:
+        """Return self<value."""
+
+    def __ne__(self, value: typing.Any) -> bool:
+        """Return self!=value."""
+
     def __repr__(self) -> str:
         """Return repr(self)."""
 
@@ -875,7 +893,26 @@ class SpacecraftODSolution:
     @staticmethod
     def from_parquet(path: typing.Any, devices: typing.Any) -> typing.Any: ...
     def is_filter_run(self) -> typing.Any: ...
-    def is_nees_consistent(
+    def is_normal(self, alpha: typing.Any = None) -> typing.Any:
+        """Checks whether the whitened residuals of the accepted residuals pass a normality test at a given significance level `alpha`, default to 0.05.
+
+        This uses a simplified KS-test threshold: D_alpha = c(α) / √n.
+        For example, for α = 0.05, c(α) is approximately 1.36.
+        α=0.05 means a 5% probability of Type I error (incorrectly rejecting the null hypothesis when it is true).
+        This threshold is standard in many statistical tests to balance sensitivity and false positives
+
+        The computation of the c(alpha) is from https://en.wikipedia.org/w/index.php?title=Kolmogorov%E2%80%93Smirnov_test&oldid=1280260701#Two-sample_Kolmogorov%E2%80%93Smirnov_test
+
+        Returns Ok(true) if the residuals are consistent with a normal distribution,
+        Ok(false) if not, or None if no residuals are available."""
+
+    def is_smoother_run(self) -> typing.Any: ...
+    def ks_test_normality(self) -> typing.Any:
+        """Computes the Kolmogorov–Smirnov statistic for the aggregated residual ratios of the accepted residuals.
+
+        Returns Ok(ks_statistic) if residuals are available."""
+
+    def nees_consistency(
         self, truth_traj: typing.Any, alpha: typing.Any = None
     ) -> typing.Any:
         """Checks whether the filter estimates are statistically consistent
@@ -895,7 +932,7 @@ class SpacecraftODSolution:
         Returns Ok(true) if the filter is consistent, Ok(false) if the filter
         is over-confident or under-confident, or an error if no estimates are available."""
 
-    def is_nis_consistent(self, alpha: typing.Any = None) -> typing.Any:
+    def nis_consistency(self, alpha: typing.Any = None) -> typing.Any:
         """Checks whether the filter innovations are statistically consistent
         by performing a Chi-squared test on the Normalized Innovation Squared (NIS).
 
@@ -910,25 +947,6 @@ class SpacecraftODSolution:
 
         Returns Ok(true) if the filter is consistent, Ok(false) if the filter
         is over-confident or under-confident, or an error if no residuals are available."""
-
-    def is_normal(self, alpha: typing.Any = None) -> typing.Any:
-        """Checks whether the whitened residuals of the accepted residuals pass a normality test at a given significance level `alpha`, default to 0.05.
-
-        This uses a simplified KS-test threshold: D_alpha = c(α) / √n.
-        For example, for α = 0.05, c(α) is approximately 1.36.
-        α=0.05 means a 5% probability of Type I error (incorrectly rejecting the null hypothesis when it is true).
-        This threshold is standard in many statistical tests to balance sensitivity and false positives
-
-        The computation of the c(alpha) is from https://en.wikipedia.org/w/index.php?title=Kolmogorov%E2%80%93Smirnov_test&oldid=1280260701#Two-sample_Kolmogorov%E2%80%93Smirnov_test
-
-        Returns Ok(true) if the residuals are consistent with a normal distribution,
-        Ok(false) if not, or None if no residuals are available."""
-
-    def is_smoother_run(self) -> typing.Any: ...
-    def ks_test_normality(self) -> typing.Any:
-        """Computes the Kolmogorov–Smirnov statistic for the aggregated residual ratios of the accepted residuals.
-
-        Returns Ok(ks_statistic) if residuals are available."""
 
     def rejected_residuals(self) -> typing.Any: ...
     def residual_ratio_within_threshold(self, threshold: typing.Any) -> typing.Any:
@@ -1278,10 +1296,10 @@ class TrackingDataArc:
     def apply_moduli(self) -> typing.Any:
         """Applies the moduli to each measurement, if defined."""
 
-    def chunk(self, max_duration: typing.Any) -> TrackingDataArc:
+    def chunk(self, max_duration: typing.Any) -> typing.Any:
         """Splits a long tracking data arc into smaller chunks, each up to `max_duration` long."""
 
-    def downsample(self, target_step: time.Duration) -> TrackingDataArc:
+    def downsample(self, target_step: time.Duration) -> Self:
         """Downsamples the tracking data to a lower frequency using a simple moving average low-pass filter followed by decimation,
         returning new `TrackingDataArc` with downsampled measurements.
 
@@ -1315,17 +1333,19 @@ class TrackingDataArc:
     def end_epoch(self) -> typing.Any:
         """Returns the end epoch of this tracking arc"""
 
-    def exclude_by_epoch(self, start: typing.Any, end: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def exclude_measurement_type(self, msr_type: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def exclude_tracker(self, tracker: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def filter_by_epoch(self, start: typing.Any, end: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def filter_by_measurement_type(self, msr_type: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def filter_by_offset(self, start: typing.Any, end: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
-    def filter_by_tracker(self, tracker: typing.Any) -> nyx_space.orbit_determination.TrackingDataArc: ...
+    def exclude_by_epoch(self, start: typing.Any, end: typing.Any) -> typing.Any: ...
+    def exclude_measurement_type(self, msr_type: typing.Any) -> typing.Any: ...
+    def exclude_tracker(self, tracker: typing.Any) -> typing.Any: ...
+    def filter_by_epoch(self, start: typing.Any, end: typing.Any) -> typing.Any: ...
+    def filter_by_measurement_type(self, msr_type: typing.Any) -> typing.Any: ...
+    def filter_by_offset(self, start: typing.Any, end: typing.Any) -> typing.Any: ...
+    def filter_by_tracker(self, tracker: typing.Any) -> typing.Any: ...
     @staticmethod
-    def from_ccsds_tdm(path: str, aliases: dict) -> nyx_space.orbit_determination.TrackingDataArc:
+    def from_ccsds_tdm(path: str, aliases: dict) -> nyx_space.od.TrackingDataArc:
         """Initializes a new Almanac from a file path to CCSDS OEM file, after converting to to SPICE SPK/BSP"""
 
+    @staticmethod
+    def from_parquet(path: typing.Any) -> typing.Any: ...
     def is_empty(self) -> typing.Any:
         """Returns whether this arc has no measurements."""
 
@@ -1345,6 +1365,7 @@ class TrackingDataArc:
     def start_epoch(self) -> typing.Any:
         """Returns the start epoch of this tracking arc"""
 
+    def to_parquet(self, path: typing.Any, cfg: typing.Any) -> typing.Any: ...
     def unique_aliases(self) -> typing.Any: ...
     def unique_types(self) -> typing.Any: ...
     def write_ccsds_tdm(

--- a/nyx-py/src/py_od.rs
+++ b/nyx-py/src/py_od.rs
@@ -30,8 +30,8 @@ use nyx_space::mc::{MvnSpacecraft, StateDispersion};
 use nyx_space::od::blse::Estimate;
 use nyx_space::od::estimate::KfEstimate;
 use nyx_space::od::prelude::{
-    KalmanVariant, ODError, ODSolution, Residual, SigmaRejection, SpacecraftKalmanScalarOD,
-    TrackingArcSim, TrkConfig,
+    KalmanVariant, NormalizedConsistency, ODError, ODSolution, Residual, SigmaRejection,
+    SpacecraftKalmanScalarOD, TrackingArcSim, TrkConfig,
 };
 use nyx_space::od::snc::ProcessNoise3D;
 use nyx_space::propagators::PropagationError;
@@ -499,8 +499,8 @@ impl PySpacecraftODSolution {
     /// Returns Ok(true) if the filter is consistent, Ok(false) if the filter
     /// is over-confident or under-confident, or an error if no residuals are available.
     #[pyo3(signature=(alpha=None))]
-    pub fn is_nis_consistent(&self, alpha: Option<f64>) -> Result<bool, ODError> {
-        self.inner.is_nis_consistent(alpha)
+    pub fn nis_consistency(&self, alpha: Option<f64>) -> Result<NormalizedConsistency, ODError> {
+        self.inner.nis_consistency(alpha)
     }
 
     /// Checks whether the filter estimates are statistically consistent
@@ -520,12 +520,12 @@ impl PySpacecraftODSolution {
     /// Returns Ok(true) if the filter is consistent, Ok(false) if the filter
     /// is over-confident or under-confident, or an error if no estimates are available.
     #[pyo3(signature=(truth_traj, alpha=None))]
-    pub fn is_nees_consistent(
+    pub fn nees_consistency(
         &self,
         truth_traj: &PyTrajectory,
         alpha: Option<f64>,
-    ) -> Result<bool, ODError> {
-        self.inner.is_nees_consistent(&truth_traj.inner, alpha)
+    ) -> Result<NormalizedConsistency, ODError> {
+        self.inner.nees_consistency(&truth_traj.inner, alpha)
     }
 
     /// Smoothes this OD solution, returning a new OD solution and the filter-smoother consistency ratios, with updated **postfit** residuals, and where the ratio now represents the filter-smoother consistency ratio.

--- a/nyx-py/tests/test_orbit_determination.py
+++ b/nyx-py/tests/test_orbit_determination.py
@@ -368,8 +368,12 @@ def test_howto_exec_orbit_determination_filter():
     nees = od_dev_sol.nees_consistency(traj)
     nees.log()
     print(f"{nees}")
-    assert nees.is_underconfident() == nis_consistency.is_underconfident(), "NIS and NEES should agree"
-    assert nees.is_overconfident() == nis_consistency.is_overconfident(), "NIS and NEES should agree"
+    assert nees.is_underconfident() == nis_consistency.is_underconfident(), (
+        "NIS and NEES should agree"
+    )
+    assert nees.is_overconfident() == nis_consistency.is_overconfident(), (
+        "NIS and NEES should agree"
+    )
     try:
         assert nees.is_consistent()
     except AssertionError:

--- a/nyx-py/tests/test_orbit_determination.py
+++ b/nyx-py/tests/test_orbit_determination.py
@@ -356,13 +356,22 @@ def test_howto_exec_orbit_determination_filter():
     )
     od_dev_sol = od_proc_deviation.process_arc(estimate, trk_arc)
     # The OD solution provides statistical tests.
+    nis_consistency = od_dev_sol.nis_consistency()
+    print(f"{nis_consistency}")
+    # Print the information to the log
+    nis_consistency.log()
     try:
-        assert od_dev_sol.is_nis_consistent()
+        assert nis_consistency.is_consistent()
     except AssertionError:
         print("deviation tracking on small dispersions are typically underconfident")
 
+    nees = od_dev_sol.nees_consistency(traj)
+    nees.log()
+    print(f"{nees}")
+    assert nees.is_underconfident() == nis_consistency.is_underconfident(), "NIS and NEES should agree"
+    assert nees.is_overconfident() == nis_consistency.is_overconfident(), "NIS and NEES should agree"
     try:
-        assert od_dev_sol.is_nees_consistent(traj)
+        assert nees.is_consistent()
     except AssertionError:
         print("and this is confirmed in the NEES metric")
 
@@ -414,8 +423,8 @@ def test_howto_exec_orbit_determination_filter():
     # This includes estimated states, prefits, postfits, covariance, sigmas on orbital elements, Kalman gains, etc.
     od_sol.to_parquet("od_ref_update.pq", ExportCfg(False))
 
-    print(od_sol.is_nis_consistent())
-    print(od_sol.is_nees_consistent(traj))
+    print(od_sol.nis_consistency())
+    print(od_sol.nees_consistency(traj))
     # We can export this solution to an OEM
     definitive_ephem = od_sol.to_ephemeris("Test OD Spacecraft")
     oem_filepath = "definitive_ephem.oem"
@@ -433,8 +442,8 @@ def test_howto_exec_orbit_determination_filter():
     od_sol_5sigma = od_proc.process_arc(estimate, trk_arc)
     assert od_sol_5sigma.is_filter_run(), "5-Sigma threshold run failed to execute."
 
-    print(od_sol_5sigma.is_nis_consistent())
-    print(od_sol_5sigma.is_nees_consistent(traj))
+    print(od_sol_5sigma.nis_consistency())
+    print(od_sol_5sigma.nees_consistency(traj))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

The NEES metric is now much more robust thanks to Eigenvalue decomposition.

Also fixed a bug in the smoother: the STM is now correctly inverted using an LU decomposition instead of a UDU. The UDU decomposition requires the matrix to be PSD, but of course the STM is not even symmetric.

## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

Removed the `ODSolution`'s `is_nis_consistent` and `is_nees_consistent`, replacing them with `nis_consistency` and `nees_consistency`. Both return a `NormalizedConsistency` struct, also exposed to Python.

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

No change

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

The smoother previously (and incorrectly) used a stable UDU decomposition for inverting the STM. That was wrong because UDU only works for positive semi definite matrices but the STM is not even symmetric, let alone PSD.

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

Dozens of filter runs from Python using a non-committed Jupyter notebook. Mainly compared the reported NEES consistency to the RIC diff between the OD solution and truth.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->