### PR TITLE
Add criterion benchmark and flamegraph generation for frame transformations

### DIFF
--- a/nyx-core/Cargo.toml
+++ b/nyx-core/Cargo.toml
@@ -61,6 +61,7 @@ premium = []
 python = ["pyo3", "hifitime/python", "anise/python"]
 
 [dev-dependencies]
+criterion = "0.5.1"
 polars = { version = "0.54.0", features = ["parquet"] }
 rstest = "0.26.1"
 pretty_env_logger = "0.5"
@@ -130,3 +131,9 @@ path = "examples/06_lunar_orbit_determination/main.rs"
 doc-scrape-examples = true
 
 
+
+
+
+[[bench]]
+name = "anise_bench"
+harness = false

--- a/nyx-core/benches/anise_bench.rs
+++ b/nyx-core/benches/anise_bench.rs
@@ -1,0 +1,31 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use anise::prelude::Almanac;
+use anise::constants::frames::*;
+use hifitime::Epoch;
+
+fn bench_transformations(c: &mut Criterion) {
+    // Determine path based on running context (workspace root vs nyx-core dir)
+    let path = if std::path::Path::new("data/01_planetary/de440s.bsp").exists() {
+        "data/01_planetary/de440s.bsp"
+    } else {
+        "../data/01_planetary/de440s.bsp"
+    };
+
+    let ctx = Almanac::default().load(path).unwrap();
+    let epoch = Epoch::from_gregorian_utc_at_midnight(2021, 1, 1);
+
+    c.bench_function("single translation", |b| b.iter(|| {
+        ctx.translate(EARTH_J2000, MOON_J2000, epoch, None).unwrap()
+    }));
+
+    c.bench_function("single rotation", |b| b.iter(|| {
+        ctx.rotate(EARTH_J2000, MOON_J2000, epoch).unwrap()
+    }));
+
+    c.bench_function("full transformation", |b| b.iter(|| {
+        ctx.transform(EARTH_J2000, MOON_J2000, epoch, None).unwrap()
+    }));
+}
+
+criterion_group!(benches, bench_transformations);
+criterion_main!(benches);

--- a/run_flamegraphs.sh
+++ b/run_flamegraphs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if ! command -v cargo-flamegraph &> /dev/null; then
+    echo "cargo-flamegraph could not be found. Please install it using 'cargo install flamegraph'."
+    exit 1
+fi
+
+echo "Running flamegraph for 'single translation'..."
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="" cargo flamegraph -p nyx-space --bench anise_bench -o flamegraph_translation.svg -- "single translation" --bench
+
+echo "Running flamegraph for 'single rotation'..."
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="" cargo flamegraph -p nyx-space --bench anise_bench -o flamegraph_rotation.svg -- "single rotation" --bench
+
+echo "Running flamegraph for 'full transformation'..."
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="" cargo flamegraph -p nyx-space --bench anise_bench -o flamegraph_transformation.svg -- "full transformation" --bench
+
+echo "Flamegraphs generated: flamegraph_translation.svg, flamegraph_rotation.svg, flamegraph_transformation.svg"


### PR DESCRIPTION
This PR introduces a criterion benchmark to evaluate the performance of underlying SPICE frame operations via the `anise::prelude::Almanac` methods `translate`, `rotate`, and `transform`.

It defines:
1. `anise_bench` as a criterion harness testing single translation, single rotation, and full transformation.
2. A bash script `run_flamegraphs.sh` which executes `cargo flamegraph` correctly configured to capture output metrics against these new benchmarks.

---
*PR created automatically by Jules for task [1446053564852365197](https://jules.google.com/task/1446053564852365197) started by @ChristopherRabotin*