### PR TITLE
Add harris priester drag model

### DIFF
--- a/nyx-core/Cargo.toml
+++ b/nyx-core/Cargo.toml
@@ -53,6 +53,7 @@ num-traits = "=0.2.19"
 # Optional dependencies
 pyo3 = {workspace = true, optional = true}
 csv = "1.4.0"
+trig-const = "0.4.0"
 
 
 [features]

--- a/nyx-core/src/dynamics/drag/mod.rs
+++ b/nyx-core/src/dynamics/drag/mod.rs
@@ -32,6 +32,7 @@ use serde_dhall::StaticType;
 use snafu::ResultExt;
 use std::fmt;
 use std::sync::Arc;
+use trig_const::{ln, sqrt};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -40,121 +41,133 @@ use pyo3::types::PyType;
 
 pub mod nrlmsise00;
 
+const SIN_30_DEG: f64 = 0.5;
+const COS_30_DEG: f64 = sqrt(3.0_f64) / 2.0_f64;
+
 /// Standard Harris-Priester altitude profile node (100 km to 1000 km)
 /// Densities in kg/m^3
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 struct HpNode {
     alt_km: f64,
-    min_density: f64,
-    max_density: f64,
+    min_density_kg_m3: f64,
+    max_density_kg_m3: f64,
+}
+
+impl HpNode {
+    const fn ln_min_density(&self) -> f64 {
+        ln(self.min_density_kg_m3)
+    }
+    const fn ln_max_density(&self) -> f64 {
+        ln(self.max_density_kg_m3)
+    }
 }
 
 /// Baseline Harris-Priester reference table for mean solar activity (~F10.7 = 150)
 const HP_TABLE: &[HpNode] = &[
     HpNode {
         alt_km: 100.0,
-        min_density: 4.974e-07,
-        max_density: 4.974e-07,
+        min_density_kg_m3: 4.974e-07,
+        max_density_kg_m3: 4.974e-07,
     },
     HpNode {
         alt_km: 120.0,
-        min_density: 2.490e-08,
-        max_density: 2.490e-08,
+        min_density_kg_m3: 2.490e-08,
+        max_density_kg_m3: 2.490e-08,
     },
     HpNode {
         alt_km: 140.0,
-        min_density: 3.840e-09,
-        max_density: 3.840e-09,
+        min_density_kg_m3: 3.840e-09,
+        max_density_kg_m3: 3.840e-09,
     },
     HpNode {
         alt_km: 160.0,
-        min_density: 1.170e-09,
-        max_density: 1.170e-09,
+        min_density_kg_m3: 1.170e-09,
+        max_density_kg_m3: 1.170e-09,
     },
     HpNode {
         alt_km: 180.0,
-        min_density: 4.820e-10,
-        max_density: 5.220e-10,
+        min_density_kg_m3: 4.820e-10,
+        max_density_kg_m3: 5.220e-10,
     },
     HpNode {
         alt_km: 200.0,
-        min_density: 2.260e-10,
-        max_density: 2.620e-10,
+        min_density_kg_m3: 2.260e-10,
+        max_density_kg_m3: 2.620e-10,
     },
     HpNode {
         alt_km: 240.0,
-        min_density: 6.880e-11,
-        max_density: 9.380e-11,
+        min_density_kg_m3: 6.880e-11,
+        max_density_kg_m3: 9.380e-11,
     },
     HpNode {
         alt_km: 280.0,
-        min_density: 2.570e-11,
-        max_density: 4.180e-11,
+        min_density_kg_m3: 2.570e-11,
+        max_density_kg_m3: 4.180e-11,
     },
     HpNode {
         alt_km: 320.0,
-        min_density: 1.090e-11,
-        max_density: 2.060e-11,
+        min_density_kg_m3: 1.090e-11,
+        max_density_kg_m3: 2.060e-11,
     },
     HpNode {
         alt_km: 360.0,
-        min_density: 4.980e-12,
-        max_density: 1.070e-11,
+        min_density_kg_m3: 4.980e-12,
+        max_density_kg_m3: 1.070e-11,
     },
     HpNode {
         alt_km: 400.0,
-        min_density: 2.380e-12,
-        max_density: 5.820e-12,
+        min_density_kg_m3: 2.380e-12,
+        max_density_kg_m3: 5.820e-12,
     },
     HpNode {
         alt_km: 440.0,
-        min_density: 1.180e-12,
-        max_density: 3.250e-12,
+        min_density_kg_m3: 1.180e-12,
+        max_density_kg_m3: 3.250e-12,
     },
     HpNode {
         alt_km: 480.0,
-        min_density: 6.020e-13,
-        max_density: 1.860e-12,
+        min_density_kg_m3: 6.020e-13,
+        max_density_kg_m3: 1.860e-12,
     },
     HpNode {
         alt_km: 520.0,
-        min_density: 3.150e-13,
-        max_density: 1.080e-12,
+        min_density_kg_m3: 3.150e-13,
+        max_density_kg_m3: 1.080e-12,
     },
     HpNode {
         alt_km: 560.0,
-        min_density: 1.680e-13,
-        max_density: 6.400e-13,
+        min_density_kg_m3: 1.680e-13,
+        max_density_kg_m3: 6.400e-13,
     },
     HpNode {
         alt_km: 600.0,
-        min_density: 9.100e-14,
-        max_density: 3.830e-13,
+        min_density_kg_m3: 9.100e-14,
+        max_density_kg_m3: 3.830e-13,
     },
     HpNode {
         alt_km: 680.0,
-        min_density: 2.820e-14,
-        max_density: 1.440e-13,
+        min_density_kg_m3: 2.820e-14,
+        max_density_kg_m3: 1.440e-13,
     },
     HpNode {
         alt_km: 760.0,
-        min_density: 9.200e-15,
-        max_density: 5.760e-14,
+        min_density_kg_m3: 9.200e-15,
+        max_density_kg_m3: 5.760e-14,
     },
     HpNode {
         alt_km: 840.0,
-        min_density: 3.100e-15,
-        max_density: 2.400e-14,
+        min_density_kg_m3: 3.100e-15,
+        max_density_kg_m3: 2.400e-14,
     },
     HpNode {
         alt_km: 920.0,
-        min_density: 1.100e-15,
-        max_density: 1.050e-14,
+        min_density_kg_m3: 1.100e-15,
+        max_density_kg_m3: 1.050e-14,
     },
     HpNode {
         alt_km: 1000.0,
-        min_density: 4.000e-16,
-        max_density: 4.800e-15,
+        min_density_kg_m3: 4.000e-16,
+        max_density_kg_m3: 4.800e-15,
     },
 ];
 
@@ -180,7 +193,7 @@ pub enum AtmDensity {
     /// degrades rapidly outside a narrow altitude band around $h_0$.
     Exponential {
         /// Reference atmospheric density $\rho_0$ at altitude $h_0$ [kg/m³].
-        rho0: f64,
+        rho0_kg_m3: f64,
         /// Reference geodetic altitude $h_0$ [km].
         ref_alt_km: f64,
         /// Atmospheric scale height $H = \frac{R T}{M g}$ [km].
@@ -228,7 +241,7 @@ impl AtmDensity {
     #[classmethod]
     fn earth_exponential(_cls: &Bound<'_, PyType>) -> Self {
         AtmDensity::Exponential {
-            rho0: 3.614e-13,
+            rho0_kg_m3: 3.614e-13,
             ref_alt_km: 700.000,
             scale_height_km: 88.667,
         }
@@ -256,7 +269,7 @@ impl Drag {
     pub fn earth_exp(almanac: &Almanac) -> Result<Arc<Self>, DynamicsError> {
         Ok(Arc::new(Self {
             density: AtmDensity::Exponential {
-                rho0: 3.614e-13,
+                rho0_kg_m3: 3.614e-13,
                 ref_alt_km: 700.000,
                 scale_height_km: 88.667,
             },
@@ -300,7 +313,7 @@ impl Drag {
             AtmDensity::Constant(rho) => *rho,
 
             AtmDensity::Exponential {
-                rho0,
+                rho0_kg_m3,
                 scale_height_km,
                 ref_alt_km,
             } => {
@@ -308,7 +321,7 @@ impl Drag {
                     .altitude_km()
                     .context(AstroPhysicsSnafu)
                     .context(DynamicsAstroSnafu)?;
-                rho0 * (-(altitude_km - ref_alt_km) / scale_height_km).exp()
+                rho0_kg_m3 * (-(altitude_km - ref_alt_km) / scale_height_km).exp()
             }
 
             AtmDensity::StdAtm { max_alt_km } => {
@@ -384,11 +397,13 @@ impl Drag {
                     let n1 = &HP_TABLE[idx + 1];
 
                     // Scale height interpolation for min and max density
-                    let h_min = (n0.alt_km - n1.alt_km) / (n1.min_density / n0.min_density).ln();
-                    let h_max = (n0.alt_km - n1.alt_km) / (n1.max_density / n0.max_density).ln();
+                    let h_min =
+                        (n0.alt_km - n1.alt_km) / (n1.ln_min_density() - n0.ln_min_density());
+                    let h_max =
+                        (n0.alt_km - n1.alt_km) / (n1.ln_max_density() - n0.ln_max_density());
 
-                    let rho_min = n0.min_density * (-(altitude_km - n0.alt_km) / h_min).exp();
-                    let rho_max = n0.max_density * (-(altitude_km - n0.alt_km) / h_max).exp();
+                    let rho_min = n0.min_density_kg_m3 * (-(altitude_km - n0.alt_km) / h_min).exp();
+                    let rho_max = n0.max_density_kg_m3 * (-(altitude_km - n0.alt_km) / h_max).exp();
 
                     // Compute Sun unit vector in drag frame
                     let u_sun = almanac
@@ -397,13 +412,10 @@ impl Drag {
                             action: "fetching sun position for Harris-Priester model",
                         })?;
 
-                    // Diurnal bulge apex: lagging Sun by ~30 deg (0.5235987756 rad) in Right Ascension
-                    let lag = 30.0_f64.to_radians();
-                    let cos_l = lag.cos();
-                    let sin_l = lag.sin();
+                    // Diurnal bulge apex: lagging Sun by ~30 deg in Right Ascension
                     let u_bulge = Vector3::new(
-                        u_sun.x * cos_l - u_sun.y * sin_l,
-                        u_sun.x * sin_l + u_sun.y * cos_l,
+                        u_sun.x * COS_30_DEG - u_sun.y * SIN_30_DEG,
+                        u_sun.x * SIN_30_DEG + u_sun.y * COS_30_DEG,
                         u_sun.z,
                     );
 

--- a/nyx-core/src/dynamics/drag/mod.rs
+++ b/nyx-core/src/dynamics/drag/mod.rs
@@ -40,6 +40,124 @@ use pyo3::types::PyType;
 
 pub mod nrlmsise00;
 
+/// Standard Harris-Priester altitude profile node (100 km to 1000 km)
+/// Densities in kg/m^3
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+struct HpNode {
+    alt_km: f64,
+    min_density: f64,
+    max_density: f64,
+}
+
+/// Baseline Harris-Priester reference table for mean solar activity (~F10.7 = 150)
+const HP_TABLE: &[HpNode] = &[
+    HpNode {
+        alt_km: 100.0,
+        min_density: 4.974e-07,
+        max_density: 4.974e-07,
+    },
+    HpNode {
+        alt_km: 120.0,
+        min_density: 2.490e-08,
+        max_density: 2.490e-08,
+    },
+    HpNode {
+        alt_km: 140.0,
+        min_density: 3.840e-09,
+        max_density: 3.840e-09,
+    },
+    HpNode {
+        alt_km: 160.0,
+        min_density: 1.170e-09,
+        max_density: 1.170e-09,
+    },
+    HpNode {
+        alt_km: 180.0,
+        min_density: 4.820e-10,
+        max_density: 5.220e-10,
+    },
+    HpNode {
+        alt_km: 200.0,
+        min_density: 2.260e-10,
+        max_density: 2.620e-10,
+    },
+    HpNode {
+        alt_km: 240.0,
+        min_density: 6.880e-11,
+        max_density: 9.380e-11,
+    },
+    HpNode {
+        alt_km: 280.0,
+        min_density: 2.570e-11,
+        max_density: 4.180e-11,
+    },
+    HpNode {
+        alt_km: 320.0,
+        min_density: 1.090e-11,
+        max_density: 2.060e-11,
+    },
+    HpNode {
+        alt_km: 360.0,
+        min_density: 4.980e-12,
+        max_density: 1.070e-11,
+    },
+    HpNode {
+        alt_km: 400.0,
+        min_density: 2.380e-12,
+        max_density: 5.820e-12,
+    },
+    HpNode {
+        alt_km: 440.0,
+        min_density: 1.180e-12,
+        max_density: 3.250e-12,
+    },
+    HpNode {
+        alt_km: 480.0,
+        min_density: 6.020e-13,
+        max_density: 1.860e-12,
+    },
+    HpNode {
+        alt_km: 520.0,
+        min_density: 3.150e-13,
+        max_density: 1.080e-12,
+    },
+    HpNode {
+        alt_km: 560.0,
+        min_density: 1.680e-13,
+        max_density: 6.400e-13,
+    },
+    HpNode {
+        alt_km: 600.0,
+        min_density: 9.100e-14,
+        max_density: 3.830e-13,
+    },
+    HpNode {
+        alt_km: 680.0,
+        min_density: 2.820e-14,
+        max_density: 1.440e-13,
+    },
+    HpNode {
+        alt_km: 760.0,
+        min_density: 9.200e-15,
+        max_density: 5.760e-14,
+    },
+    HpNode {
+        alt_km: 840.0,
+        min_density: 3.100e-15,
+        max_density: 2.400e-14,
+    },
+    HpNode {
+        alt_km: 920.0,
+        min_density: 1.100e-15,
+        max_density: 1.050e-14,
+    },
+    HpNode {
+        alt_km: 1000.0,
+        min_density: 4.000e-16,
+        max_density: 4.800e-15,
+    },
+];
+
 /// Density in kg/m^3 and altitudes in kilometers
 #[derive(Clone, Debug, Serialize, Deserialize, StaticType)]
 #[cfg_attr(feature = "python", pyclass(from_py_object, get_all, set_all))]
@@ -87,6 +205,16 @@ pub enum AtmDensity {
     /// as a function of location, time, solar activity (F10.7), and geomagnetic
     /// activity (Ap).
     NRLMSISE00 { weather: SpaceWeatherData },
+
+    /// Harris-Priester atmospheric density model.
+    ///
+    /// Computes density accounting for diurnal atmospheric expansion using tabular
+    /// min/max density profiles interpolated exponentially across altitude bands,
+    /// modified by the diurnal bulge angle offset.
+    HarrisPriester {
+        /// Diurnal bulge parameter $n$ (typically 2 for low inclination, 6 for polar).
+        n_parameter: usize,
+    },
 }
 
 #[cfg(feature = "python")]
@@ -233,6 +361,62 @@ impl Drag {
                     ctx.orbit.epoch,
                 )?
                 .total_mass_density_kg_m3
+            }
+
+            AtmDensity::HarrisPriester { n_parameter } => {
+                let altitude_km = osc_drag_frame
+                    .altitude_km()
+                    .context(AstroPhysicsSnafu)
+                    .context(DynamicsAstroSnafu)?;
+
+                if altitude_km < HP_TABLE[0].alt_km
+                    || altitude_km > HP_TABLE[HP_TABLE.len() - 1].alt_km
+                {
+                    0.0
+                } else {
+                    // Find altitude layer
+                    let idx = HP_TABLE
+                        .windows(2)
+                        .position(|w| altitude_km >= w[0].alt_km && altitude_km <= w[1].alt_km)
+                        .unwrap_or(0);
+
+                    let n0 = &HP_TABLE[idx];
+                    let n1 = &HP_TABLE[idx + 1];
+
+                    // Scale height interpolation for min and max density
+                    let h_min = (n0.alt_km - n1.alt_km) / (n1.min_density / n0.min_density).ln();
+                    let h_max = (n0.alt_km - n1.alt_km) / (n1.max_density / n0.max_density).ln();
+
+                    let rho_min = n0.min_density * (-(altitude_km - n0.alt_km) / h_min).exp();
+                    let rho_max = n0.max_density * (-(altitude_km - n0.alt_km) / h_max).exp();
+
+                    // Compute Sun unit vector in drag frame
+                    let u_sun = almanac
+                        .sun_unit_vector(ctx.orbit.epoch, self.frame, None)
+                        .context(DynamicsAlmanacSnafu {
+                            action: "fetching sun position for Harris-Priester model",
+                        })?;
+
+                    // Diurnal bulge apex: lagging Sun by ~30 deg (0.5235987756 rad) in Right Ascension
+                    let lag = 30.0_f64.to_radians();
+                    let cos_l = lag.cos();
+                    let sin_l = lag.sin();
+                    let u_bulge = Vector3::new(
+                        u_sun.x * cos_l - u_sun.y * sin_l,
+                        u_sun.x * sin_l + u_sun.y * cos_l,
+                        u_sun.z,
+                    );
+
+                    // Cosine of angle between spacecraft position vector and diurnal bulge apex
+                    let u_pos = osc_drag_frame.r_hat();
+                    let cos_psi = u_pos.dot(&u_bulge).clamp(-1.0, 1.0);
+
+                    // Diurnal variation modifier: cos^(n)(psi / 2)
+                    let cos_half_psi = ((1.0 + cos_psi) / 2.0).sqrt();
+                    let mod_factor = cos_half_psi.powi(*n_parameter as i32);
+
+                    rho_min + (rho_max - rho_min) * mod_factor
+                }
             }
         };
 

--- a/nyx-core/tests/mission_design/force_models.rs
+++ b/nyx-core/tests/mission_design/force_models.rs
@@ -565,3 +565,92 @@ fn val_ioastro_nrlmsise00(almanac: Arc<Almanac>) {
     assert!(dbg!(ric_error.rmag_km()) < 0.72);
     assert!(dbg!(ric_error.vmag_km_s()) < 2e-3);
 }
+
+#[rstest]
+fn regression_harris_drag(almanac: Arc<Almanac>) {
+    let eme2k = almanac
+        .frame_info(EARTH_J2000)
+        .unwrap()
+        .with_mu_km3_s2(GMAT_EARTH_GM);
+
+    let iau_earth = almanac
+        .frame_info(IAU_EARTH_FRAME)
+        .unwrap()
+        .with_mu_km3_s2(GMAT_EARTH_GM);
+
+    let epoch = Epoch::from_gregorian_utc_hms(2024, 2, 29, 1, 2, 3);
+
+    let orbit = Orbit::new(
+        -6210.6003575395861844,
+        -445.9010437211380236,
+        2353.4286399045840881,
+        -0.6027299684384100,
+        -7.2371397713442924,
+        -2.7084864602730194,
+        epoch,
+        eme2k,
+    );
+
+    println!("Initial: {orbit:x}");
+
+    let spacecraft = Spacecraft::builder()
+        .orbit(orbit)
+        .mass(Mass::from_dry_mass(1000.0))
+        .drag(DragData {
+            area_m2: 20.0,
+            coeff_drag: 2.2,
+        })
+        .build();
+
+    // Define the dynamics
+    let earth_sph_harm = GravityFieldData::from_j2(EARTH_J2, iau_earth);
+    let j2_mdl = GravityField::new(earth_sph_harm);
+
+    let dynamics = SpacecraftDynamics::from_models(
+        OrbitalDynamics::from_model(j2_mdl),
+        vec![Arc::new(Drag {
+            density: AtmDensity::HarrisPriester { n_parameter: 2 },
+            frame: iau_earth,
+            estimate: false,
+        })],
+    );
+
+    let final_state = Propagator::default(dynamics)
+        .with(spacecraft, almanac.clone())
+        .for_duration(1.0 * Unit::Day)
+        .unwrap()
+        .orbit;
+
+    let expected_state = Orbit::new(
+        -5866.260358,
+        1429.893388,
+        2719.496468,
+        -2.783483,
+        -6.933258,
+        -2.187250,
+        Epoch::from_gregorian_utc_hms(2024, 3, 1, 1, 2, 3),
+        eme2k,
+    );
+
+    let ric_error = expected_state.ric_difference(&final_state).unwrap();
+
+    println!("=== Cartesian ===\nGot:  {final_state}");
+    println!("Want: {expected_state}");
+
+    println!("=== Keplerian ===\nGot:  {final_state:x}");
+    println!("Want: {expected_state:x}");
+
+    println!(
+        "RIC pos error (km) = {:.6}\n{:.6}",
+        ric_error.rmag_km(),
+        ric_error.radius_km
+    );
+    println!(
+        "RIC vel error (km/s) = {:.6}\n{:.6}",
+        ric_error.vmag_km_s(),
+        ric_error.velocity_km_s
+    );
+
+    assert!(dbg!(ric_error.rmag_km()) < 2e-5);
+    assert!(dbg!(ric_error.vmag_km_s()) < 2e-6);
+}

--- a/nyx-core/tests/mission_design/force_models.rs
+++ b/nyx-core/tests/mission_design/force_models.rs
@@ -622,8 +622,8 @@ fn regression_harris_drag(almanac: Arc<Almanac>) {
         .orbit;
 
     let expected_state = Orbit::new(
-        -5866.260358,
-        1429.893388,
+        -5866.260366,
+        1429.893370,
         2719.496468,
         -2.783483,
         -6.933258,
@@ -653,4 +653,35 @@ fn regression_harris_drag(almanac: Arc<Almanac>) {
 
     assert!(dbg!(ric_error.rmag_km()) < 2e-5);
     assert!(dbg!(ric_error.vmag_km_s()) < 2e-6);
+
+    // For checking purposes, add the diff to NRLMSISE00.
+
+    let expected_state = Orbit::new(
+        -5904.4748605974446036,
+        1330.9542946601800395,
+        2687.0267716822277180,
+        -2.6688074464373877,
+        -6.9600802661844208,
+        -2.2412448735527049,
+        Epoch::from_gregorian_utc_hms(2024, 3, 1, 1, 2, 3),
+        eme2k,
+    );
+    let ric_error = expected_state.ric_difference(&final_state).unwrap();
+    println!("*** NRLMSISE-00 COMPARISON ***");
+    println!("=== Cartesian ===\nGot:  {final_state}");
+    println!("Want: {expected_state}");
+
+    println!("=== Keplerian ===\nGot:  {final_state:x}");
+    println!("Want: {expected_state:x}");
+
+    println!(
+        "RIC pos error (km) = {:.6}\n{:.6}",
+        ric_error.rmag_km(),
+        ric_error.radius_km
+    );
+    println!(
+        "RIC vel error (km/s) = {:.6}\n{:.6}",
+        ric_error.vmag_km_s(),
+        ric_error.velocity_km_s
+    );
 }


### PR DESCRIPTION
# Summary

Harris Priester drag model is a simple mean solar activity model (akin to F10.7 ~= 150 SFU). It performs a simple exponential density interpolation in between altitude bands. It accounts for diurnal atmospheric expansion with a bulge angle offset.

Verification tests show that NRLMSISE00 is ~100 km off the HP model for the same test case. In general, one should prefer MSISE.


## Architectural Changes

<!-- List any architectural changes made in this pull request, including any changes to the directory structure, file organization, or dependencies. -->

No change

## New Features

<!-- List any new features added in this pull request, including any new tools or functionality. -->

HarrisPriester enum variant for AtmDensity.

## Improvements

<!-- List any improvements made in this pull request, including any performance optimizations, bug fixes, or other enhancements. -->

No change

## Bug Fixes

<!-- List any bug fixes made in this pull request, including any issues that were resolved. -->

No change

## Testing and validation

<!-- Please provide information on how the changes in this pull request were tested, including any new tests that were added or existing tests that were modified. -->

- Only tested the difference between HP and NRLMSISE00, then build a _regression_ test to ensure no regression on that HP model.

## Documentation

<!-- Detail documentation changes if this pull request primarily deals with documentation. -->

This PR does not primarily deal with documentation changes.

<!-- Thank you for contributing to Nyx! -->